### PR TITLE
refactor(log-surge): use snake case for pipeline config

### DIFF
--- a/pipelines/log-surge/log-surge.toml
+++ b/pipelines/log-surge/log-surge.toml
@@ -4,7 +4,7 @@ input_topics = ["te/device/main///logs/journald"]
 filter = "dist/main.mjs"
 tick_every_seconds = 1
 
-config.withLogs = true
+config.with_logs = true
 config.debug = false
 config.publish_statistics = true
 config.stats_topic = "stats/logs"
@@ -15,4 +15,4 @@ config.threshold.info = 10
 
 # Optional log message filter, which will only include log entries
 # where the message text matches the given regex
-# config.textFilter = ["(connectdfasdf)"]
+# config.text_filter = ["(connect)"]

--- a/pipelines/log-surge/src/main.ts
+++ b/pipelines/log-surge/src/main.ts
@@ -10,10 +10,10 @@ import * as testing from "../../common/testing";
 export interface Config {
   // Enable debug logging
   debug?: boolean;
-  withLogs?: boolean;
+  with_logs?: boolean;
   publish_statistics?: boolean;
   stats_topic?: string;
-  textFilter?: string[];
+  text_filter?: string[];
   threshold?: {
     info?: number;
     warning?: number;
@@ -48,7 +48,7 @@ export function get_state(): FlowState {
 export function process(
   timestamp: Timestamp,
   message: Message,
-  { withLogs = false, debug = false, textFilter = [] }: Config = {},
+  { with_logs = false, debug = false, text_filter = [] }: Config = {},
 ) {
   TEST: if (debug) {
     console.log("Calling process");
@@ -66,7 +66,7 @@ export function process(
       return element.test(text);
     };
   };
-  if (!textFilter.map((v) => RegExp(v)).every(contains(output.text))) {
+  if (!text_filter.map((v) => RegExp(v)).every(contains(output.text))) {
     TEST: if (debug) {
       console.log("Skipping message", {});
     }
@@ -77,7 +77,7 @@ export function process(
   state.stats[output.level] += 1;
   state.stats.total += 1;
 
-  if (withLogs) {
+  if (with_logs) {
     return [
       {
         topic: "stream/logs/journald",
@@ -169,7 +169,7 @@ TEST: testing.run(1, "test", () => {
     payload: JSON.stringify(value),
   }));
   const config: Config = {
-    withLogs: true,
+    with_logs: true,
     publish_statistics: true,
     debug: false,
     threshold: {

--- a/pipelines/log-surge/tests/main.test.ts
+++ b/pipelines/log-surge/tests/main.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   flow.get_state().ran = false;
 });
 
-test("Config withLogs returns the log entries", () => {
+test("Config with_logs returns the log entries", () => {
   const message: tedge.Message = {
     topic: "dummy",
     payload: JSON.stringify(<journald.JOURNALD_RAW_MESSAGE>{
@@ -17,12 +17,12 @@ test("Config withLogs returns the log entries", () => {
     }),
   };
   const output1 = flow.process(tedge.mockGetTime(), message, <flow.Config>{
-    withLogs: true,
+    with_logs: true,
   });
   expect(output1).toHaveLength(1);
 
   const output2 = flow.process(tedge.mockGetTime(), message, <flow.Config>{
-    withLogs: false,
+    with_logs: false,
   });
   expect(output2).toHaveLength(0);
 });
@@ -32,8 +32,8 @@ describe.each([
   ["Some log message", [".*(important).*"], 0],
   ["Some log message", [], 1],
 ])(
-  "textFilter can be used to filter log messages",
-  (text: string, textFilter: string[], expected: number) => {
+  "text_filter can be used to filter log messages",
+  (text: string, text_filter: string[], expected: number) => {
     test("matches the expected count", () => {
       const message: tedge.Message = {
         topic: "dummy",
@@ -43,8 +43,8 @@ describe.each([
         }),
       };
       const output = flow.process(tedge.mockGetTime(), message, <flow.Config>{
-        textFilter,
-        withLogs: true,
+        text_filter,
+        with_logs: true,
       });
       expect(output).toHaveLength(expected);
     });
@@ -92,7 +92,7 @@ describe.each([
         }),
       },
       <flow.Config>{
-        withLogs: true,
+        with_logs: true,
       },
     );
     expect(output).toHaveLength(1);
@@ -157,7 +157,7 @@ describe.each([
 
 test("Process mock data", () => {
   const config: flow.Config = {
-    withLogs: false,
+    with_logs: false,
     debug: false,
     publish_statistics: true,
     stats_topic: "stats/logs",
@@ -167,7 +167,7 @@ test("Process mock data", () => {
       error: 0,
       total: 0,
     },
-    textFilter: [],
+    text_filter: [],
   };
   const messages: tedge.Message[] = journald
     .mockJournaldLogs(10)
@@ -260,7 +260,7 @@ describe.each([
     1,
   ],
 ])(
-  "textFilter can be used to filter log messages",
+  "text_filter can be used to filter log messages",
   (
     testCase: string,
     config: flow.Config,


### PR DESCRIPTION
Improve consistency of the pipeline configuration to use the same naming convention.