### PR TITLE
feat: add modem manager data mapper

### DIFF
--- a/flows/modem-manager/README.md
+++ b/flows/modem-manager/README.md
@@ -1,0 +1,186 @@
+## modem-manager
+
+Publish modem manager (cellular) information including cell tower id which can be used for tracking.
+
+### Description
+
+- Detect changes of the cell tower id
+- Send data periodically - configurable interval
+
+The flow is represented by the following steps:
+
+- Detect changes in the cell tower id, and send an event to the cloud to determine location information
+- Publish c8y_Mobile information about the modem (using modem manager data)
+
+### Input
+
+The flow expects the modem manager input json in the following format:
+
+**JSON payload**
+
+```json
+{
+  "sim": {
+    "dbus-path": "/org/freedesktop/ModemManager1/SIM/0",
+    "properties": {
+      "active": "yes",
+      "eid": "--",
+      "emergency-numbers": [],
+      "esim-status": "--",
+      "gid1": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "gid2": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "iccid": "8949360000421790514",
+      "imsi": "262231017669630",
+      "operator-code": "26223",
+      "operator-name": "1&1",
+      "preferred-networks": [
+        "operator-code: 26223, access-technologies: lte",
+        "operator-code: 20801, access-technologies: gsm, umts, lte"
+      ],
+      "removability": "--",
+      "sim-type": "--"
+    }
+  },
+  "modem": {
+    "location": {
+      "3gpp": {
+        "cid": "00A49109",
+        "lac": "0000",
+        "mcc": "262",
+        "mnc": "02",
+        "tac": "00AD2B"
+      },
+      "cdma-bs": {
+        "latitude": "--",
+        "longitude": "--"
+      },
+      "gps": {
+        "altitude": "--",
+        "latitude": "--",
+        "longitude": "--",
+        "nmea": [],
+        "utc": "--"
+      }
+    },
+    "3gpp": {
+      "5gnr": {
+        "registration-settings": {
+          "drx-cycle": "--",
+          "mico-mode": "--"
+        }
+      },
+      "enabled-locks": ["fixed-dialing"],
+      "eps": {
+        "initial-bearer": {
+          "dbus-path": "/org/freedesktop/ModemManager1/Bearer/1",
+          "settings": {
+            "apn": "--",
+            "ip-type": "--",
+            "password": "--",
+            "user": "--"
+          }
+        },
+        "ue-mode-operation": "csps-1"
+      },
+      "imei": "860018046114881",
+      "network-rejection-access-technology": "--",
+      "network-rejection-error": "--",
+      "network-rejection-operator-id": "--",
+      "network-rejection-operator-name": "--",
+      "operator-code": "26202",
+      "operator-name": "Vodafone.de",
+      "packet-service-state": "attached",
+      "pco": "--",
+      "registration-state": "home"
+    },
+    "cdma": {
+      "activation-state": "--",
+      "cdma1x-registration-state": "--",
+      "esn": "--",
+      "evdo-registration-state": "--",
+      "meid": "--",
+      "nid": "--",
+      "sid": "--"
+    },
+    "dbus-path": "/org/freedesktop/ModemManager1/Modem/0",
+    "generic": {
+      "access-technologies": ["lte"],
+      "bearers": ["/org/freedesktop/ModemManager1/Bearer/0"],
+      "carrier-configuration": "--",
+      "carrier-configuration-revision": "--",
+      "current-bands": [
+        "utran-1",
+        "utran-8",
+        "eutran-1",
+        "eutran-3",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-20",
+        "eutran-38",
+        "eutran-40",
+        "eutran-41"
+      ],
+      "current-capabilities": ["gsm-umts, lte"],
+      "current-modes": "allowed: 3g, 4g; preferred: 3g",
+      "device": "qcom-soc",
+      "device-identifier": "69bc305f94b9e998c1f05afae06af3eb2f806829",
+      "drivers": ["bam-dmux", "qcom-q6v5-mss", "rpmsg_ctrl"],
+      "equipment-identifier": "860018046114881",
+      "hardware-revision": "10000",
+      "manufacturer": "1",
+      "model": "0",
+      "own-numbers": [],
+      "physdev": "/sys/devices/platform/soc@0/4080000.remoteproc/4080000.remoteproc:bam-dmux",
+      "plugin": "qcom-soc",
+      "ports": [
+        "rpmsg_ctrl2 (ignored)",
+        "wwan0 (net)",
+        "wwan0at0 (at)",
+        "wwan0at1 (at)",
+        "wwan0qmi0 (qmi)"
+      ],
+      "power-state": "on",
+      "primary-port": "wwan0qmi0",
+      "primary-sim-slot": "1",
+      "revision": "UZ801_V3.0_21_V01R01B10  1  [Sep 07 2015 23:00:00]",
+      "signal-quality": {
+        "recent": "yes",
+        "value": "80"
+      },
+      "sim": "/org/freedesktop/ModemManager1/SIM/0",
+      "sim-slots": ["/org/freedesktop/ModemManager1/SIM/0", "/"],
+      "state": "connected",
+      "state-failed-reason": "--",
+      "supported-bands": [
+        "utran-1",
+        "utran-8",
+        "eutran-1",
+        "eutran-3",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-20",
+        "eutran-38",
+        "eutran-40",
+        "eutran-41"
+      ],
+      "supported-capabilities": ["gsm-umts, lte"],
+      "supported-ip-families": ["ipv4", "ipv6", "ipv4v6"],
+      "supported-modes": [
+        "allowed: 3g; preferred: none",
+        "allowed: 4g; preferred: none",
+        "allowed: 3g, 4g; preferred: 4g",
+        "allowed: 3g, 4g; preferred: 3g"
+      ],
+      "unlock-required": "sim-pin2",
+      "unlock-retries": [
+        "sim-pin (3)",
+        "sim-puk (10)",
+        "sim-pin2 (3)",
+        "sim-puk2 (10)"
+      ]
+    }
+  }
+}
+```

--- a/flows/modem-manager/flow.toml
+++ b/flows/modem-manager/flow.toml
@@ -1,0 +1,7 @@
+[input]
+mqtt.topics = [
+    "te/device/main///source/modemManager",
+]
+
+[[steps]]
+script = "dist/main.mjs"

--- a/flows/modem-manager/jest.config.ts
+++ b/flows/modem-manager/jest.config.ts
@@ -1,0 +1,19 @@
+/** @jest-config-loader esbuild-register */
+import type { Config } from "jest";
+
+const esbuildOptions = {
+  target: "es2018",
+  // ignore labels for test coverage
+  dropLabels: ["TEST", "DEV"],
+};
+
+const config: Config = {
+  verbose: true,
+  transform: { "^.+\\.ts?$": ["jest-esbuild", esbuildOptions] },
+  testEnvironment: "node",
+  testRegex: "/tests/.*\\.(test|spec)?\\.(ts|tsx)$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  coverageReporters: ["clover", "json", "lcov", ["text", { skipFull: true }]],
+};
+
+export default config;

--- a/flows/modem-manager/package.json
+++ b/flows/modem-manager/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "modem-manager",
+  "version": "1.0.0",
+  "description": "Publish meta information about the modem as digital twin and send an alert when the cell id has changed",
+  "source": "src/main.ts",
+  "module": "dist/main.mjs",
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=dist/main.mjs --format=esm --drop-labels=DEV,TEST",
+    "test": "jest --coverageProvider=v8 --coverage"
+  },
+  "author": "thin-edge.io",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "esbuild": "^0.25.5",
+    "esbuild-register": "^3.6.0",
+    "jest": "^30.0.4",
+    "jest-esbuild": "^0.4.0",
+    "prettier": "3.6.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/flows/modem-manager/src/main.ts
+++ b/flows/modem-manager/src/main.ts
@@ -1,0 +1,124 @@
+/*
+  Publish modem information
+*/
+import { Message } from "../../common/tedge";
+
+export interface Config {
+  interval_sec?: number;
+}
+
+export interface Mobile {
+  currentOperator?: String;
+  iccid?: String;
+  cellId?: String;
+  imei?: String;
+  imsi?: String;
+  mcc?: String;
+  mnc?: String;
+  lac?: String;
+  connType?: String;
+  signalQuality?: Number;
+}
+
+export interface State {
+  mobile: Mobile;
+}
+
+const state: State = {
+  mobile: {},
+};
+
+function hasChanged(obj1, obj2): boolean {
+  return JSON.stringify(obj1) !== JSON.stringify(obj2);
+}
+
+export function onMessage(message: Message, config: Config): Message[] {
+  const payload = JSON.parse(message.payload);
+  const output: Message[] = [];
+
+  const mobile: Mobile = {};
+
+  // sim details
+  if (payload.hasOwnProperty("sim")) {
+    mobile.iccid = payload?.sim?.properties?.iccid;
+    mobile.imsi = payload?.sim?.properties?.imsi;
+  }
+
+  // modem details
+  if (
+    payload.hasOwnProperty("modem") &&
+    payload["modem"].hasOwnProperty("3gpp")
+  ) {
+    mobile.currentOperator = payload["modem"]["3gpp"]["operator-name"];
+    mobile.imei = payload["modem"]["3gpp"]["imei"];
+  }
+
+  mobile.connType = (payload?.modem?.generic["access-technologies"] || []).join(
+    ",",
+  );
+
+  // signalQuality
+  const signalQualityRecent = payload?.modem?.generic["signal-quality"].recent;
+  const signalQualityPercentageRaw =
+    payload?.modem?.generic["signal-quality"].value;
+  const signalQualityPercentage = parseInt(signalQualityPercentageRaw, 10);
+  if (isFinite(signalQualityPercentage)) {
+    mobile.signalQuality = signalQualityPercentage;
+  }
+
+  // location details
+  if (
+    payload.hasOwnProperty("modem") &&
+    payload["modem"].hasOwnProperty("location")
+  ) {
+    const location = payload["modem"]["location"];
+    mobile.cellId = Number(`0x${location["3gpp"]["cid"]}`).toFixed(0);
+    mobile.mcc = location["3gpp"]["mcc"];
+    mobile.mnc = location["3gpp"]["mnc"];
+
+    const locationAreaCode = Number(`0x${location["3gpp"]["lac"]}`);
+    const trackingAreaCode = Number(`0x${location["3gpp"]["tac"]}`);
+    if (locationAreaCode === 0) {
+      mobile.lac = trackingAreaCode.toFixed(0);
+    } else {
+      mobile.lac = locationAreaCode.toFixed(0);
+    }
+  }
+
+  if (hasChanged(mobile, state.mobile)) {
+    output.push({
+      topic: "te/device/main///twin/c8y_Mobile",
+      retain: true,
+      payload: JSON.stringify({
+        ...mobile,
+        lastChanged: new Date(message.timestamp.seconds * 1000).toISOString(),
+      }),
+      timestamp: message.timestamp,
+    });
+  }
+
+  // cell tower change detection
+  if (!!state.mobile.cellId && state.mobile.cellId !== mobile.cellId) {
+    output.push({
+      topic: "te/device/main///e/cellTowerDetails",
+      payload: JSON.stringify({
+        text: "Cell tower changed",
+        previousCellTowerDetails: {
+          mcc: state.mobile.mcc,
+          mnc: state.mobile.mnc,
+          lac: state.mobile.lac,
+        },
+        cellTowerDetails: {
+          mcc: mobile.mcc,
+          mnc: mobile.mnc,
+          lac: mobile.lac,
+        },
+      }),
+      timestamp: message.timestamp,
+    });
+  }
+
+  state.mobile = mobile;
+
+  return output;
+}

--- a/flows/modem-manager/tests/data/location.json
+++ b/flows/modem-manager/tests/data/location.json
@@ -1,0 +1,24 @@
+{
+  "modem": {
+    "location": {
+      "3gpp": {
+        "cid": "00A49109",
+        "lac": "0000",
+        "mcc": "262",
+        "mnc": "02",
+        "tac": "00AD2B"
+      },
+      "cdma-bs": {
+        "latitude": "--",
+        "longitude": "--"
+      },
+      "gps": {
+        "altitude": "--",
+        "latitude": "--",
+        "longitude": "--",
+        "nmea": [],
+        "utc": "--"
+      }
+    }
+  }
+}

--- a/flows/modem-manager/tests/data/modem.json
+++ b/flows/modem-manager/tests/data/modem.json
@@ -1,0 +1,123 @@
+{
+  "modem": {
+    "3gpp": {
+      "5gnr": {
+        "registration-settings": {
+          "drx-cycle": "--",
+          "mico-mode": "--"
+        }
+      },
+      "enabled-locks": ["fixed-dialing"],
+      "eps": {
+        "initial-bearer": {
+          "dbus-path": "/org/freedesktop/ModemManager1/Bearer/1",
+          "settings": {
+            "apn": "--",
+            "ip-type": "--",
+            "password": "--",
+            "user": "--"
+          }
+        },
+        "ue-mode-operation": "csps-1"
+      },
+      "imei": "860018046114881",
+      "network-rejection-access-technology": "--",
+      "network-rejection-error": "--",
+      "network-rejection-operator-id": "--",
+      "network-rejection-operator-name": "--",
+      "operator-code": "26202",
+      "operator-name": "Vodafone.de",
+      "packet-service-state": "attached",
+      "pco": "--",
+      "registration-state": "home"
+    },
+    "cdma": {
+      "activation-state": "--",
+      "cdma1x-registration-state": "--",
+      "esn": "--",
+      "evdo-registration-state": "--",
+      "meid": "--",
+      "nid": "--",
+      "sid": "--"
+    },
+    "dbus-path": "/org/freedesktop/ModemManager1/Modem/0",
+    "generic": {
+      "access-technologies": ["lte"],
+      "bearers": ["/org/freedesktop/ModemManager1/Bearer/0"],
+      "carrier-configuration": "--",
+      "carrier-configuration-revision": "--",
+      "current-bands": [
+        "utran-1",
+        "utran-8",
+        "eutran-1",
+        "eutran-3",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-20",
+        "eutran-38",
+        "eutran-40",
+        "eutran-41"
+      ],
+      "current-capabilities": ["gsm-umts, lte"],
+      "current-modes": "allowed: 3g, 4g; preferred: 3g",
+      "device": "qcom-soc",
+      "device-identifier": "69bc305f94b9e998c1f05afae06af3eb2f806829",
+      "drivers": ["bam-dmux", "qcom-q6v5-mss", "rpmsg_ctrl"],
+      "equipment-identifier": "860018046114881",
+      "hardware-revision": "10000",
+      "manufacturer": "1",
+      "model": "0",
+      "own-numbers": [],
+      "physdev": "/sys/devices/platform/soc@0/4080000.remoteproc/4080000.remoteproc:bam-dmux",
+      "plugin": "qcom-soc",
+      "ports": [
+        "rpmsg_ctrl2 (ignored)",
+        "wwan0 (net)",
+        "wwan0at0 (at)",
+        "wwan0at1 (at)",
+        "wwan0qmi0 (qmi)"
+      ],
+      "power-state": "on",
+      "primary-port": "wwan0qmi0",
+      "primary-sim-slot": "1",
+      "revision": "UZ801_V3.0_21_V01R01B10  1  [Sep 07 2015 23:00:00]",
+      "signal-quality": {
+        "recent": "yes",
+        "value": "80"
+      },
+      "sim": "/org/freedesktop/ModemManager1/SIM/0",
+      "sim-slots": ["/org/freedesktop/ModemManager1/SIM/0", "/"],
+      "state": "connected",
+      "state-failed-reason": "--",
+      "supported-bands": [
+        "utran-1",
+        "utran-8",
+        "eutran-1",
+        "eutran-3",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-20",
+        "eutran-38",
+        "eutran-40",
+        "eutran-41"
+      ],
+      "supported-capabilities": ["gsm-umts, lte"],
+      "supported-ip-families": ["ipv4", "ipv6", "ipv4v6"],
+      "supported-modes": [
+        "allowed: 3g; preferred: none",
+        "allowed: 4g; preferred: none",
+        "allowed: 3g, 4g; preferred: 4g",
+        "allowed: 3g, 4g; preferred: 3g"
+      ],
+      "unlock-required": "sim-pin2",
+      "unlock-retries": [
+        "sim-pin (3)",
+        "sim-puk (10)",
+        "sim-pin2 (3)",
+        "sim-puk2 (10)"
+      ]
+    }
+  }
+}

--- a/flows/modem-manager/tests/data/modem.sh
+++ b/flows/modem-manager/tests/data/modem.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -e
+SIMULATE=${SIMULATE:-0}
+INTERVAL=${INTERVAL:-60}
+OUTPUT=${OUTPUT:-mqtt}
+TOPIC=${TOPIC:-"te/device/main///source/modemManager"}
+
+dir=$(CDPATH="" cd -- "$(dirname -- "$0")" && pwd)
+
+SUDO=
+if [ "$(id -u)" != 0 ]; then
+    if command -V sudo >/dev/null 2>&1; then
+        SUDO=sudo
+    fi
+fi
+
+collect() {
+    if [ "$SIMULATE" = 1 ]; then
+        echo "Using simulated data" >&2
+        SIM=$(cat "$dir/sim.json")
+        LOCATION=$(cat "$dir/location.json")
+        MODEM=$(cat "$dir/modem.json")
+    else
+        MODEM=$($SUDO mmcli --modem any -J || echo '{}')
+        SIM=$($SUDO mmcli --sim any -J || echo '{}')
+        LOCATION=$($SUDO mmcli --modem any --location-get -J || echo '{}')
+    fi
+
+    case "$OUTPUT" in
+        stdout)
+            echo "$SIM" "$LOCATION" "$MODEM" | jq -s '.[0] * .[1] * .[2]'
+            ;;
+        mqtt)
+            PAYLOAD=$(echo "$SIM" "$LOCATION" "$MODEM" | jq -s '.[0] * .[1] * .[2]')
+            tedge mqtt pub "$TOPIC" "$PAYLOAD"
+            ;;
+    esac
+}
+
+usage() {
+    cat <<EOT
+Get modem information from modem manager
+
+$0 [--interval <sec>] [--topic <topic>]
+
+ARGUMENTS
+  --interval <sec>          Collect the modem information every x seconds
+                            Default: 60
+  --topic <topic>           MQTT Topic to publish the modem information to.
+                            Default: te/device/main///source/modemManager
+  --output <stdout|mqtt>    Where to output the messages to.
+                            Default: mqtt
+
+EXAMPLES
+  $0 --interval 60 --topic te/device/main///source/modemManager --output mqtt
+  Publish modem information every 60 seconds to the te/device/main///source/modemManager topic
+
+  $0 --output stdout --interval 0
+  Get modem information once and print out to stdout
+EOT
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --interval)
+            INTERVAL="$2"
+            shift
+            ;;
+        --output)
+            OUTPUT="$2"
+            shift
+            ;;
+        --topic)
+            TOPIC="$2"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+    esac
+    shift
+done
+
+if [ "$INTERVAL" -gt 0 ]; then
+    while true; do
+        collect
+        sleep "$INTERVAL"
+    done
+else
+    collect
+fi

--- a/flows/modem-manager/tests/data/sim.json
+++ b/flows/modem-manager/tests/data/sim.json
@@ -1,0 +1,23 @@
+{
+  "sim": {
+    "dbus-path": "/org/freedesktop/ModemManager1/SIM/0",
+    "properties": {
+      "active": "yes",
+      "eid": "--",
+      "emergency-numbers": [],
+      "esim-status": "--",
+      "gid1": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "gid2": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "iccid": "8949360000421790514",
+      "imsi": "262231017669630",
+      "operator-code": "26223",
+      "operator-name": "1&1",
+      "preferred-networks": [
+        "operator-code: 26223, access-technologies: lte",
+        "operator-code: 20801, access-technologies: gsm, umts, lte"
+      ],
+      "removability": "--",
+      "sim-type": "--"
+    }
+  }
+}

--- a/flows/modem-manager/tests/data/tedge-modem.service
+++ b/flows/modem-manager/tests/data/tedge-modem.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=tedge-modem publishes modem manager information periodically to an mqtt topic
+After=syslog.target network-online.target
+
+[Service]
+User=root
+ExecStart=/usr/bin/tedge-modem.sh --output mqtt
+Restart=on-failure
+RestartPreventExitStatus=255
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/flows/modem-manager/tests/data/testMessage1.json
+++ b/flows/modem-manager/tests/data/testMessage1.json
@@ -1,0 +1,164 @@
+{
+  "sim": {
+    "dbus-path": "/org/freedesktop/ModemManager1/SIM/0",
+    "properties": {
+      "active": "yes",
+      "eid": "--",
+      "emergency-numbers": [],
+      "esim-status": "--",
+      "gid1": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "gid2": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+      "iccid": "8949360000421790514",
+      "imsi": "262231017669630",
+      "operator-code": "26223",
+      "operator-name": "1&1",
+      "preferred-networks": [
+        "operator-code: 26223, access-technologies: lte",
+        "operator-code: 20801, access-technologies: gsm, umts, lte"
+      ],
+      "removability": "--",
+      "sim-type": "--"
+    }
+  },
+  "modem": {
+    "location": {
+      "3gpp": {
+        "cid": "00A49109",
+        "lac": "0000",
+        "mcc": "262",
+        "mnc": "02",
+        "tac": "00AD2B"
+      },
+      "cdma-bs": {
+        "latitude": "--",
+        "longitude": "--"
+      },
+      "gps": {
+        "altitude": "--",
+        "latitude": "--",
+        "longitude": "--",
+        "nmea": [],
+        "utc": "--"
+      }
+    },
+    "3gpp": {
+      "5gnr": {
+        "registration-settings": {
+          "drx-cycle": "--",
+          "mico-mode": "--"
+        }
+      },
+      "enabled-locks": ["fixed-dialing"],
+      "eps": {
+        "initial-bearer": {
+          "dbus-path": "/org/freedesktop/ModemManager1/Bearer/1",
+          "settings": {
+            "apn": "--",
+            "ip-type": "--",
+            "password": "--",
+            "user": "--"
+          }
+        },
+        "ue-mode-operation": "csps-1"
+      },
+      "imei": "860018046114881",
+      "network-rejection-access-technology": "--",
+      "network-rejection-error": "--",
+      "network-rejection-operator-id": "--",
+      "network-rejection-operator-name": "--",
+      "operator-code": "26202",
+      "operator-name": "Vodafone.de",
+      "packet-service-state": "attached",
+      "pco": "--",
+      "registration-state": "home"
+    },
+    "cdma": {
+      "activation-state": "--",
+      "cdma1x-registration-state": "--",
+      "esn": "--",
+      "evdo-registration-state": "--",
+      "meid": "--",
+      "nid": "--",
+      "sid": "--"
+    },
+    "dbus-path": "/org/freedesktop/ModemManager1/Modem/0",
+    "generic": {
+      "access-technologies": ["lte"],
+      "bearers": ["/org/freedesktop/ModemManager1/Bearer/0"],
+      "carrier-configuration": "--",
+      "carrier-configuration-revision": "--",
+      "current-bands": [
+        "utran-1",
+        "utran-8",
+        "eutran-1",
+        "eutran-3",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-20",
+        "eutran-38",
+        "eutran-40",
+        "eutran-41"
+      ],
+      "current-capabilities": ["gsm-umts, lte"],
+      "current-modes": "allowed: 3g, 4g; preferred: 3g",
+      "device": "qcom-soc",
+      "device-identifier": "69bc305f94b9e998c1f05afae06af3eb2f806829",
+      "drivers": ["bam-dmux", "qcom-q6v5-mss", "rpmsg_ctrl"],
+      "equipment-identifier": "860018046114881",
+      "hardware-revision": "10000",
+      "manufacturer": "1",
+      "model": "0",
+      "own-numbers": [],
+      "physdev": "/sys/devices/platform/soc@0/4080000.remoteproc/4080000.remoteproc:bam-dmux",
+      "plugin": "qcom-soc",
+      "ports": [
+        "rpmsg_ctrl2 (ignored)",
+        "wwan0 (net)",
+        "wwan0at0 (at)",
+        "wwan0at1 (at)",
+        "wwan0qmi0 (qmi)"
+      ],
+      "power-state": "on",
+      "primary-port": "wwan0qmi0",
+      "primary-sim-slot": "1",
+      "revision": "UZ801_V3.0_21_V01R01B10  1  [Sep 07 2015 23:00:00]",
+      "signal-quality": {
+        "recent": "yes",
+        "value": "80"
+      },
+      "sim": "/org/freedesktop/ModemManager1/SIM/0",
+      "sim-slots": ["/org/freedesktop/ModemManager1/SIM/0", "/"],
+      "state": "connected",
+      "state-failed-reason": "--",
+      "supported-bands": [
+        "utran-1",
+        "utran-8",
+        "eutran-1",
+        "eutran-3",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-20",
+        "eutran-38",
+        "eutran-40",
+        "eutran-41"
+      ],
+      "supported-capabilities": ["gsm-umts, lte"],
+      "supported-ip-families": ["ipv4", "ipv6", "ipv4v6"],
+      "supported-modes": [
+        "allowed: 3g; preferred: none",
+        "allowed: 4g; preferred: none",
+        "allowed: 3g, 4g; preferred: 4g",
+        "allowed: 3g, 4g; preferred: 3g"
+      ],
+      "unlock-required": "sim-pin2",
+      "unlock-retries": [
+        "sim-pin (3)",
+        "sim-puk (10)",
+        "sim-pin2 (3)",
+        "sim-puk2 (10)"
+      ]
+    }
+  }
+}

--- a/flows/modem-manager/tests/main.test.ts
+++ b/flows/modem-manager/tests/main.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@jest/globals";
+import * as tedge from "../../common/tedge";
+import * as testMessage1 from "./data/testMessage1.json";
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+describe("process", () => {
+  let flow: typeof import("../src/main");
+
+  beforeEach(() => {
+    jest.resetModules();
+    flow = require("../src/main");
+  });
+
+  test("Maps modem data to the c8y_Mobile digital twin", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "example",
+        payload: JSON.stringify(testMessage1),
+      },
+      {},
+    );
+    expect(output).toHaveLength(1);
+
+    expect(output[0].topic).toMatch(/\/twin\/c8y_Mobile$/);
+
+    const payload = JSON.parse(output[0].payload);
+    expect(payload).toHaveProperty("iccid", "8949360000421790514");
+    expect(payload).toHaveProperty("imsi", "262231017669630");
+    expect(payload).toHaveProperty("currentOperator", "Vodafone.de");
+    expect(payload).toHaveProperty("imei", "860018046114881");
+    expect(payload).toHaveProperty("cellId", "10785033");
+    expect(payload).toHaveProperty("lac", "44331");
+    expect(payload).toHaveProperty("lac", "44331");
+    expect(payload).toHaveProperty("connType", "lte");
+  });
+
+  test("It only publishes on changes", () => {
+    const output1 = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "example",
+        payload: JSON.stringify(testMessage1),
+      },
+      {},
+    );
+    expect(output1).toHaveLength(1);
+
+    const output2 = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "example",
+        payload: JSON.stringify(testMessage1),
+      },
+      {},
+    );
+    expect(output2).toHaveLength(0);
+  });
+
+  test("Sends an event when the cell id changes", () => {
+    const message1 = clone(testMessage1);
+    const output1 = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "example",
+        payload: JSON.stringify(message1),
+      },
+      {},
+    );
+    expect(output1).toHaveLength(1);
+
+    const message2 = clone(testMessage1);
+    message2.modem.location["3gpp"].cid = "00A4910A";
+    const output2 = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "example",
+        payload: JSON.stringify(message2),
+      },
+      {},
+    );
+
+    expect(output2).toHaveLength(2);
+    const payload = JSON.parse(output2[0].payload);
+    expect(payload).toHaveProperty("cellId", "10785034");
+    expect(payload).toHaveProperty("lac", "44331");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,19 @@
         "typescript": "^5.8.3"
       }
     },
+    "flows/modem-manager": {
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "esbuild": "^0.25.5",
+        "esbuild-register": "^3.6.0",
+        "jest": "^30.0.4",
+        "jest-esbuild": "^0.4.0",
+        "prettier": "3.6.2",
+        "typescript": "^5.8.3"
+      }
+    },
     "flows/tedge": {
       "version": "1.0.0",
       "license": "ISC"
@@ -3912,6 +3925,10 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/modem-manager": {
+      "resolved": "flows/modem-manager",
+      "link": true
     },
     "node_modules/ms": {
       "version": "2.1.3",


### PR DESCRIPTION
Add example to map modem manager data to the c8y_Mobile fragment and add some cell tower change detection to publish the cell tower information to the cloud where additional location information can be derived from it.