### PR TITLE
Improve protobuf example to read protobuf encoded msg

### DIFF
--- a/flows/protobuf-xform/README.md
+++ b/flows/protobuf-xform/README.md
@@ -31,3 +31,22 @@ Topic: **te/device/main///m/location**
   "longitude": 153.02223634041275
 }
 ```
+
+### Decoding Protobuf messages
+
+The encoded measurements produced by the protobuf example flow ...
+
+```
+$ tedge flows test --base64-output te/device/main///m/environment '{ "temperature": 29, "humidity": 50 }'
+
+[c8y-mqtt/proto/sensor_data] ChIJAAAAAAAAPUARAAAAAAAASUA=
+```
+
+... can be decoded back by the same protobuf example flow:
+
+```
+$ tedge flows test --base64-input c8y-mqtt/proto/setpoint ChIJAAAAAAAAPUARAAAAAAAASUA=                                           
+
+[te/device/main///sig/setpoint] {"$typeName":"sensorpackage.SensorMessage","sensor":{"case":"environment","value":{"$typeName":"sensorpackage.EnvironmentSensor","metaInfo":{},"temperature":29,"humidity":50}}}
+
+```

--- a/flows/protobuf-xform/flow.toml
+++ b/flows/protobuf-xform/flow.toml
@@ -2,9 +2,12 @@
 mqtt.topics = [
     "te/device/main/+/+/m/environment",
     "te/device/main/+/+/m/location",
+    "c8y-mqtt/proto/setpoint",
 ]
 
 [[steps]]
 script = "dist/main.mjs"
 # config.topic: Use the template variable, '{{type}}' if you wish to include the sensor data type within the topic
 config.topic = "c8y-mqtt/proto/sensor_data"
+config.cmdtopic = "te/device/main///sig/setpoint"
+config.base64 = false


### PR DESCRIPTION
The encoded measurements produced by the protobuf example flow ...

```
$ tedge flows test --base64-output te/device/main///m/environment '{ "temperature": 29, "humidity": 50 }'

[c8y-mqtt/proto/sensor_data] ChIJAAAAAAAAPUARAAAAAAAASUA=
```

... can be decoded back by the same protobuf example flow:

```
$ tedge flows test --base64-input c8y-mqtt/proto/setpoint ChIJAAAAAAAAPUARAAAAAAAASUA=

[te/device/main///sig/setpoint] {"$typeName":"sensorpackage.SensorMessage","sensor":{"case":"environment","value":{"$typeName":"sensorpackage.EnvironmentSensor","metaInfo":{},"temperature":29,"humidity":50}}}

```
