### PR TITLE
chore: bump package-lock dependencies via npm audit difx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "jest": "^30.0.4",
         "jest-esbuild": "^0.4.0",
         "prettier": "3.6.2",
-        "protobufjs-cli": "^1.1.3",
         "typescript": "^5.8.3"
       }
     },
@@ -83,7 +82,7 @@
       "license": "ISC"
     },
     "flows/uptime": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@faker-js/faker": "^9.9.0",
@@ -5483,9 +5482,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Run `npm audit fix` to resolve some security notifications with some dev-only tooling.