### PR TITLE
feat: add flow to monitor the device certificate expiration date

### DIFF
--- a/flows/certificate-alert/flow.toml
+++ b/flows/certificate-alert/flow.toml
@@ -1,0 +1,31 @@
+[input.process]
+command = """sh -c \"tedge cert show | tr '\\n' '\\0'\""""
+interval = "600s"
+
+[[steps]]
+script = "dist/flow.mjs"
+
+# turn on additional debugging
+debug = false
+
+##############################
+# alerts / alarming
+##############################
+
+# disable alarming
+config.disable_alarms = false
+
+# threshold when to create a major alarm
+config.alarm = "30d"
+
+# threshold when to create a warning
+config.warning = "90d"
+
+##############################
+# certificate meta information
+##############################
+# don't publish digital twin data
+config.disable_twin = false
+
+# digital twin property where to publish the certificates meta information to
+config.twin_property = "tedge_Certificate"

--- a/flows/certificate-alert/package.json
+++ b/flows/certificate-alert/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "certificate-alert",
+  "version": "1.0.0",
+  "description": "Publish device certificate information and create alerts when the certificate is about to expire",
+  "source": "src/main.ts",
+  "module": "dist/main.mjs",
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=dist/main.mjs --format=esm --drop-labels=DEV,TEST",
+    "test": "jest --coverageProvider=v8 --coverage"
+  },
+  "author": "thin-edge.io",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@faker-js/faker": "^9.9.0",
+    "@types/jest": "^30.0.0",
+    "esbuild": "^0.25.5",
+    "esbuild-register": "^3.6.0",
+    "jest": "^30.0.4",
+    "jest-esbuild": "^0.4.0",
+    "prettier": "3.6.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/flows/certificate-alert/src/main.ts
+++ b/flows/certificate-alert/src/main.ts
@@ -1,0 +1,225 @@
+import { Message, Timestamp, Run, mockGetTime } from "./../../common/tedge";
+
+interface Config {
+  disable_twin?: boolean;
+  disable_alarms?: boolean;
+  alarm?: string;
+  warning?: string;
+  twin_property?: string;
+  debug?: boolean;
+}
+
+function camelize(value: string) {
+  return value
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, function (word, index) {
+      return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    })
+    .replace(/\s+/g, "");
+}
+
+function parseInputMessage(payload: string) {
+  return payload
+    .split("\u0000")
+    .filter((item) => item)
+    .reduce((props, item) => {
+      const [key, ...values] = item.split(":") || [];
+      const value = values.join(":");
+      if (key && values.length > 0) {
+        props[camelize(key)] = value.trimStart();
+      }
+      return props;
+    }, {} as any);
+}
+
+function parseDuration(value_str: string) {
+  // Supports formats like "90d", "12h", "30m", "45s", "100ms", and compound values like "90d 12h"
+  const regex = /(\d+)\s*(d|h|m|s|ms)/gi;
+  let total = 0;
+  let match;
+  while ((match = regex.exec(value_str)) !== null) {
+    const value = parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    switch (unit) {
+      case "d":
+        total += value * 24 * 60 * 60 * 1000;
+        break;
+      case "h":
+        total += value * 60 * 60 * 1000;
+        break;
+      case "m":
+        total += value * 60 * 1000;
+        break;
+      case "s":
+        total += value * 1000;
+        break;
+      case "ms":
+        total += value;
+        break;
+    }
+  }
+  return total || NaN;
+}
+
+const deduplicateCalls = (fn: Function) => {
+  const cache = new Map();
+  return function (...args: any[]): any[] {
+    const key: string = JSON.stringify(args);
+    if (cache.has(key)) {
+      // return cache.get(key);
+      return [];
+    }
+    const result: any[] = fn(...args);
+    cache.set(key, result);
+    return result;
+  };
+};
+
+const checkThresholds = deduplicateCalls(function (
+  expiresAt: number,
+  details: any,
+  config: any,
+) {
+  const {
+    alarm = "30d",
+    warning = "60d",
+    alarm_type = "certificateExpiresSoon",
+    debug = false,
+  } = config;
+  const alarm_threshold = parseDuration(alarm);
+  const warning_threshold = parseDuration(warning);
+  if (isNaN(alarm_threshold)) {
+    console.error("Invalid alarm threshold format", {
+      got: alarm,
+      wanted: "duration as a string, e.g. '90d'",
+    });
+  }
+  if (isNaN(warning_threshold)) {
+    console.error("Invalid warning threshold format", {
+      got: warning,
+      wanted: "duration as a string, e.g. '90d'",
+    });
+  }
+
+  const expiresIn = expiresAt - Date.now();
+  if (debug) {
+    console.debug(`Checking certificate`, {
+      expiresAt: expiresAt / 1000,
+      expiresIn: expiresIn / 1000,
+      alarm_threshold: alarm_threshold / 1000,
+      warning_threshold: warning_threshold / 1000,
+      now: Date.now(),
+    });
+  }
+
+  const topicAlarm = `te/device/main///a/${alarm_type}_alarm`;
+  const topicWarning = `te/device/main///a/${alarm_type}_warn`;
+
+  const messages = [];
+  if (expiresIn <= alarm_threshold) {
+    messages.push({
+      topic: topicAlarm,
+      retain: true,
+      payload: JSON.stringify({
+        text: `Certificate will expire within ${alarm}`,
+        severity: "major",
+        details,
+      }),
+    });
+    messages.push({
+      topic: topicWarning,
+      retain: true,
+      payload: "",
+    });
+  } else if (expiresIn <= warning_threshold) {
+    messages.push({
+      topic: topicWarning,
+      retain: true,
+      payload: JSON.stringify({
+        text: `Certificate will expire within ${warning}`,
+        severity: "warning",
+        details,
+      }),
+    });
+    messages.push({
+      topic: topicAlarm,
+      retain: true,
+      payload: "",
+    });
+  } else {
+    // Clear alarms
+    messages.push({
+      topic: topicAlarm,
+      retain: true,
+      payload: "",
+    });
+    messages.push({
+      topic: topicWarning,
+      retain: true,
+      payload: "",
+    });
+  }
+  return messages;
+});
+
+function toJSON(payload: any, debug: boolean = false) {
+  if (debug === true) {
+    return JSON.stringify(payload, null, "  ");
+  }
+  return JSON.stringify(payload);
+}
+
+const publishTwinMessage = deduplicateCalls(function (
+  output: any,
+  config: Config,
+) {
+  return [
+    {
+      topic: `te/device/main///twin/${config?.twin_property || "tedge_Certificate"}`,
+      retain: true,
+      payload: toJSON(output, config?.debug),
+    },
+  ];
+});
+
+export function onMessage(message: Message, config: Config = {}): Message[] {
+  console.debug("Input", {
+    topic: message.topic,
+    payload: message.payload,
+  });
+  const fragment = parseInputMessage(message.payload);
+
+  const expiresAt = new Date(fragment.validUntil);
+  let signedBy = "-";
+  if (fragment.issuer === fragment.subject) {
+    signedBy = "self";
+  } else if (fragment.issuer.match(/CN=t[0-9]+\b/)) {
+    signedBy = "c8y-ca";
+  } else {
+    signedBy = "ca";
+  }
+  const output = {
+    subject: fragment.subject,
+    issuer: fragment.issuer,
+    status: fragment.status.replace(/ *\(.+\)$/, ""),
+    validFrom: new Date(fragment.validFrom).toISOString(),
+    validUntil: expiresAt.toISOString(),
+    signedBy,
+    // Extract hex number in brackets, without 0x prefix
+    serialNumberHex: (() => {
+      const match = fragment.serialNumber.match(/\(0x([a-f0-9]+)\)/i);
+      return match ? match[1] : fragment.serialNumber;
+    })(),
+  };
+
+  const outputMessages = [];
+  if (!config?.disable_twin) {
+    outputMessages.push(...publishTwinMessage(output, config));
+  }
+
+  if (!config?.disable_alarms) {
+    outputMessages.push(
+      ...checkThresholds(expiresAt.getTime(), output, config),
+    );
+  }
+  return outputMessages;
+}

--- a/flows/certificate-alert/tests/main.test.ts
+++ b/flows/certificate-alert/tests/main.test.ts
@@ -1,0 +1,238 @@
+import { expect, test, describe, beforeEach } from "@jest/globals";
+import * as tedge from "../../common/tedge";
+
+jest.useFakeTimers();
+
+const inputCumulocityCA = `
+Certificate:   /etc/tedge/device-certs/tedge-certificate.pem
+Subject:       CN=example, O=Thin Edge, OU=Device
+Issuer:        C=United States, O=Cumulocity, CN=t123456
+Status:        VALID (expires in: 227d 11m 31s)
+Valid from:    Tue, 10 Jun 2025 14:03:43 +0000
+Valid until:   Wed, 10 Jun 2026 14:03:43 +0000
+Serial number: 17152455133923 (0xf999dfecae3)
+Thumbprint:    7EA936355ECCA79E7D59D275ECE1E4A8BE5E9275
+`
+  .trimStart()
+  .replaceAll("\n", "\u0000");
+
+const expectedCumulocityCAOutput = {
+  signedBy: "c8y-ca",
+  issuer: "C=United States, O=Cumulocity, CN=t123456",
+  serialNumberHex: "f999dfecae3",
+  status: "VALID",
+  subject: "CN=example, O=Thin Edge, OU=Device",
+  validFrom: "2025-06-10T14:03:43.000Z",
+  validUntil: "2026-06-10T14:03:43.000Z",
+};
+
+const inputSelfSigned = `
+Certificate:   /etc/tedge/device-certs/tedge-certificate.pem
+Subject:       CN=example, O=Thin Edge, OU=Device
+Issuer:        CN=example, O=Thin Edge, OU=Device
+Status:        VALID (expires in: 227d 11m 31s)
+Valid from:    Tue, 10 Jun 2025 14:03:43 +0000
+Valid until:   Wed, 10 Jun 2026 14:03:43 +0000
+Serial number: 17152455133923 (0xf999dfecae3)
+Thumbprint:    7EA936355ECCA79E7D59D275ECE1E4A8BE5E9275
+`
+  .trimStart()
+  .replaceAll("\n", "\u0000");
+
+const expectedSelfSigned = {
+  signedBy: "self",
+  issuer: "CN=example, O=Thin Edge, OU=Device",
+  serialNumberHex: "f999dfecae3",
+  status: "VALID",
+  subject: "CN=example, O=Thin Edge, OU=Device",
+  validFrom: "2025-06-10T14:03:43.000Z",
+  validUntil: "2026-06-10T14:03:43.000Z",
+};
+
+describe("flow tests", () => {
+  const now = new Date("2025-10-01T12:11:59Z").getTime();
+  jest.setSystemTime(now);
+  let flow: typeof import("../src/main");
+
+  beforeEach(() => {
+    jest.resetModules();
+    flow = require("../src/main");
+  });
+
+  test("Publish certificate meta information to json - c8y-ca", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputCumulocityCA,
+      },
+      {
+        disable_alarms: true,
+      },
+    );
+    expect(output).toHaveLength(1);
+    const payload = JSON.parse(output[0].payload);
+    expect(output[0].topic).toBe("te/device/main///twin/tedge_Certificate");
+    expect(output[0].retain).toBe(true);
+    expect(payload).toStrictEqual(expectedCumulocityCAOutput);
+  });
+
+  test("Publish certificate meta information to json - self signed", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputSelfSigned,
+      },
+      {
+        disable_alarms: true,
+      },
+    );
+    expect(output).toHaveLength(1);
+    const payload = JSON.parse(output[0].payload);
+    expect(output[0].topic).toBe("te/device/main///twin/tedge_Certificate");
+    expect(output[0].retain).toBe(true);
+    expect(payload).toStrictEqual(expectedSelfSigned);
+  });
+
+  test("Publish a warning when certificate crosses threshold", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputCumulocityCA,
+      },
+      {
+        disable_alarms: false,
+        warning: "300d",
+        alarm: "60d",
+      },
+    );
+    expect(output).toHaveLength(3);
+
+    // meta message
+    const payload = JSON.parse(output[0].payload);
+    expect(output[0].topic).toBe("te/device/main///twin/tedge_Certificate");
+    expect(output[0].retain).toBe(true);
+    expect(payload).toStrictEqual(expectedCumulocityCAOutput);
+
+    // alarm
+    expect(output[1].topic).toBe(
+      "te/device/main///a/certificateExpiresSoon_warn",
+    );
+    expect(output[2].retain).toBe(true);
+    const warning = JSON.parse(output[1].payload);
+    expect(warning).toStrictEqual({
+      text: "Certificate will expire within 300d",
+      severity: "warning",
+      details: expectedCumulocityCAOutput,
+    });
+
+    // clear other alarm
+    expect(output[2].topic).toBe(
+      "te/device/main///a/certificateExpiresSoon_alarm",
+    );
+    expect(output[2].payload).toBe("");
+    expect(output[2].retain).toBe(true);
+  });
+
+  test("Publish an alarm when certificate will expire less than given threshold", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputCumulocityCA,
+      },
+      {
+        disable_alarms: false,
+        warning: "365d",
+        alarm: "300d",
+      },
+    );
+    expect(output).toHaveLength(3);
+
+    // meta message
+    const payload = JSON.parse(output[0].payload);
+    expect(output[0].topic).toBe("te/device/main///twin/tedge_Certificate");
+    expect(output[0].retain).toBe(true);
+    expect(payload).toStrictEqual(expectedCumulocityCAOutput);
+
+    // alarm
+    expect(output[1].topic).toBe(
+      "te/device/main///a/certificateExpiresSoon_alarm",
+    );
+    expect(output[2].retain).toBe(true);
+    const warning = JSON.parse(output[1].payload);
+    expect(warning).toStrictEqual({
+      text: "Certificate will expire within 300d",
+      severity: "major",
+      details: expectedCumulocityCAOutput,
+    });
+
+    // clear other alarm
+    expect(output[2].topic).toBe(
+      "te/device/main///a/certificateExpiresSoon_warn",
+    );
+    expect(output[2].payload).toBe("");
+    expect(output[2].retain).toBe(true);
+  });
+
+  test("De-duplication of output", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputCumulocityCA,
+      },
+      {
+        disable_alarms: false,
+        warning: "365d",
+        alarm: "300d",
+      },
+    );
+    expect(output).toHaveLength(3);
+
+    // execute a second time with the same input
+    const output2 = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputCumulocityCA,
+      },
+      {
+        disable_alarms: false,
+        warning: "365d",
+        alarm: "300d",
+      },
+    );
+    expect(output2).toHaveLength(0);
+  });
+
+  test("Only publish alarms", () => {
+    const output = flow.onMessage(
+      {
+        timestamp: tedge.mockGetTime(),
+        topic: "",
+        payload: inputCumulocityCA,
+      },
+      {
+        disable_alarms: false,
+        disable_twin: true,
+        warning: "365d",
+        alarm: "300d",
+      },
+    );
+    expect(output).toHaveLength(2);
+
+    expect(output[0].topic).toBe(
+      "te/device/main///a/certificateExpiresSoon_alarm",
+    );
+    expect(output[0].retain).toBe(true);
+    expect(output[0].payload).toMatch(/.+/);
+    expect(output[1].topic).toBe(
+      "te/device/main///a/certificateExpiresSoon_warn",
+    );
+    expect(output[1].retain).toBe(true);
+    expect(output[1].payload).toBe("");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,20 @@
         "typescript": "^5.8.3"
       }
     },
+    "flows/certificate-alert": {
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@faker-js/faker": "^9.9.0",
+        "@types/jest": "^30.0.0",
+        "esbuild": "^0.25.5",
+        "esbuild-register": "^3.6.0",
+        "jest": "^30.0.4",
+        "jest-esbuild": "^0.4.0",
+        "prettier": "3.6.2",
+        "typescript": "^5.8.3"
+      }
+    },
     "flows/cloud-mapper-telemetry": {
       "version": "0.0.1",
       "license": "Apache-2.0",
@@ -58,7 +72,7 @@
       }
     },
     "flows/log-surge": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@faker-js/faker": "^9.9.0",
@@ -2662,6 +2676,10 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/certificate-alert": {
+      "resolved": "flows/certificate-alert",
+      "link": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",


### PR DESCRIPTION
New flow which checks the thin-edge.io device certificate expiration date and creates some alerts for it.

* Send alarm (severity=minor) when cert only has x number of days before it expires (default 90d)
* Send alarm (severity=major) when cert only has x number of days before it expires (default 30d)
* Publish meta information about the certificate