### PR TITLE
fix(cloud-mapper-commands): add check for device id in cloud topic

### DIFF
--- a/flows/cloud-mapper-commands/src/main.ts
+++ b/flows/cloud-mapper-commands/src/main.ts
@@ -38,6 +38,13 @@ function createCommand(
 ): Message[] {
   const messages: Message[] = [];
   const tedgeTopic = utils.getTedgeTopicID(message.topic);
+  if (!tedgeTopic) {
+    console.error("tedge topic is ill-formed", {
+      cloudTopic: message.topic,
+      localTopic: tedgeTopic,
+    });
+    return messages;
+  }
   const { cloud_prefix = "azeg" } = config || {};
 
   // map cloud payloads to local payload if required

--- a/flows/cloud-mapper-commands/src/utils.ts
+++ b/flows/cloud-mapper-commands/src/utils.ts
@@ -1,5 +1,13 @@
 function getTedgeTopicID(topic: string): string | undefined {
-  return ["te", topic.split("/")[2].replace("_", "/"), "/"].join("/");
+  const parts = topic.split("/");
+  if (parts.length < 3) {
+    return;
+  }
+  const cloudID = topic.split("/")[2].split("_");
+  if (cloudID.length < 2) {
+    return;
+  }
+  return ["te", ...cloudID, "/"].join("/");
 }
 
 export { getTedgeTopicID };

--- a/flows/cloud-mapper-commands/tests/utils.test.ts
+++ b/flows/cloud-mapper-commands/tests/utils.test.ts
@@ -4,9 +4,10 @@ import * as utils from "../src/utils";
 describe.each([
   ["azeg/DCMD/device_child-1/foo", "te/device/child-1//"],
   ["azeg/DCMD/device_child-2", "te/device/child-2//"],
+  ["azeg/DCMD/child-2", undefined],
 ])(
   "getDeviceUUID extracts the UUID of the device from the cloud topic",
-  (topic: string, expected: string) => {
+  (topic: string, expected?: string) => {
     test("matches UUID", () => {
       const value = utils.getTedgeTopicID(topic);
       expect(value).toBe(expected);


### PR DESCRIPTION
Add a check on the expected format for the device target in the cloud's topic