### PR TITLE
feat(jsonata-xform): allow templates to control the topic

### DIFF
--- a/flows/jsonata-xform/package.json
+++ b/flows/jsonata-xform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonata-xform",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "This flow demonstrates to use jsonata for message transformation.",
   "source": "src/main.ts",
   "module": "dist/main.mjs",

--- a/flows/jsonata-xform/src/main.ts
+++ b/flows/jsonata-xform/src/main.ts
@@ -2,19 +2,73 @@
   Calculate the total of the input values
 */
 import { Message } from "../../common/tedge";
-import { build, Substitution, DynamicMappingRule } from "./dynamicmapper";
+import {
+  build,
+  Substitution,
+  DynamicMappingRule,
+  evaluate,
+} from "./dynamicmapper";
+import { unset } from "es-toolkit/compat";
 
 export interface Config {
+  targetTopic?: string;
+  targetAPI?: string;
   substitutions?: Substitution[];
+}
+
+function buildTopic(externalID: string, ...paths: string[]): string {
+  return ["te", "device", externalID, "", "", ...paths].join("/");
 }
 
 export async function onMessage(message: Message, config: Config = {}) {
   const rule: DynamicMappingRule = {
+    targetTopic: config.targetTopic,
+    targetAPI: config.targetAPI,
     substitutions: config.substitutions || [],
   };
   const output = await build(message, rule);
+
+  // const topic = externalID || "unknown";
+  let topic = "unknown";
+
+  if (rule.targetTopic) {
+    topic = await evaluate(
+      message.payload,
+      rule.targetTopic,
+      message.topic.split("/"),
+    );
+  } else {
+    switch (rule.targetAPI) {
+      case "MEASUREMENT": {
+        const externalID = output?._IDENTITY_?.externalId;
+        topic = buildTopic(externalID, "m", output?.type || "");
+        unset(output, "_IDENTITY_");
+        break;
+      }
+
+      case "EVENT": {
+        const externalID = output?._IDENTITY_?.externalId;
+        topic = buildTopic(externalID, "e", output?.type || "");
+        unset(output, "_IDENTITY_");
+        break;
+      }
+      case "ALARM": {
+        const externalID = output?._IDENTITY_?.externalId;
+        topic = buildTopic(externalID, "a", output?.type || "");
+        unset(output, "_IDENTITY_");
+        break;
+      }
+      case "INVENTORY": {
+        const externalID = output?._IDENTITY_?.externalId;
+        topic = buildTopic(externalID, "twin", output?.type || "");
+        unset(output, "_IDENTITY_");
+        break;
+      }
+    }
+  }
+
   return {
-    topic: `${message.topic}/sum`,
+    topic,
     payload: JSON.stringify(output),
   };
 }

--- a/flows/jsonata-xform/tests/dynamicmapper.test.ts
+++ b/flows/jsonata-xform/tests/dynamicmapper.test.ts
@@ -2,61 +2,60 @@ import { expect, test } from "@jest/globals";
 import * as tedge from "../../common/tedge";
 import * as dm from "../src/dynamicmapper";
 
-test("Converts string to a timestamp", () => {
-  return dm
-    .build(
-      {
-        timestamp: tedge.mockGetTime(),
-        topic: "/plant1/line1/device1_measure1_Type",
-        payload: JSON.stringify({
-          time: 1.1234,
-          value: 100,
-          value2: 99.1,
-          dateTo: "2025-01-01 00:00",
-        }),
-      },
-      {
-        id: "asd",
-        name: "",
-        mappingTopic: "",
-        substitutions: [
-          {
-            pathSource: "$replace(dateTo,' ','T')",
-            pathTarget: "dateTo",
-          },
-          {
-            pathSource: "time",
-            pathTarget: "timestamp",
-          },
-          {
-            pathSource: "value + 1",
-            pathTarget: "some.nested.value",
-          },
-          {
-            pathSource: "value",
-            pathTarget: "some.other.value",
-          },
-          {
-            pathSource: "'˚C'",
-            pathTarget: "some.other.unit",
-          },
-        ],
-      },
-    )
-    .then((data) => {
-      expect(data).toStrictEqual({
-        dateTo: "2025-01-01T00:00",
-        timestamp: 1.1234,
+test("Converts string to a timestamp", async () => {
+  const output = await dm.build(
+    {
+      timestamp: tedge.mockGetTime(),
+      topic: "/plant1/line1/device1_measure1_Type",
+      payload: JSON.stringify({
+        time: 1.1234,
+        value: 100,
         value2: 99.1,
-        some: {
-          nested: {
-            value: 101,
-          },
-          other: {
-            value: 100,
-            unit: "˚C",
-          },
+        dateTo: "2025-01-01 00:00",
+      }),
+    },
+    {
+      id: "asd",
+      name: "",
+      mappingTopic: "",
+      targetAPI: "MEASUREMENT",
+      substitutions: [
+        {
+          pathSource: "$replace(dateTo,' ','T')",
+          pathTarget: "dateTo",
         },
-      });
-    });
+        {
+          pathSource: "time",
+          pathTarget: "timestamp",
+        },
+        {
+          pathSource: "value + 1",
+          pathTarget: "some.nested.value",
+        },
+        {
+          pathSource: "value",
+          pathTarget: "some.other.value",
+        },
+        {
+          pathSource: "'˚C'",
+          pathTarget: "some.other.unit",
+        },
+      ],
+    },
+  );
+
+  expect(output).toStrictEqual({
+    dateTo: "2025-01-01T00:00",
+    timestamp: 1.1234,
+    value2: 99.1,
+    some: {
+      nested: {
+        value: 101,
+      },
+      other: {
+        value: 100,
+        unit: "˚C",
+      },
+    },
+  });
 });

--- a/flows/jsonata-xform/tests/main.test.ts
+++ b/flows/jsonata-xform/tests/main.test.ts
@@ -2,38 +2,204 @@ import { expect, test } from "@jest/globals";
 import * as tedge from "../../common/tedge";
 import * as flow from "../src/main";
 
-test("Converts string to a timestamp", async () => {
-  return flow
-    .onMessage(
-      {
-        timestamp: tedge.mockGetTime(),
-        topic: "/plant1/line1/device1_measure1_Type",
-        payload: JSON.stringify({
-          value: 100,
-        }),
-      },
-      {
-        substitutions: [
-          {
-            pathSource: "value",
-            pathTarget: "output",
-          },
-          {
-            pathSource: "'measure1_Type'",
-            pathTarget: "type",
-          },
-          {
-            pathSource: "$now()",
-            pathTarget: "time",
-          },
-        ],
-      },
-    )
-    .then((data) => {
-      const payload = JSON.parse(data.payload);
-      expect(Object.keys(payload)).toHaveLength(3);
-      expect(payload).toHaveProperty("output", 100);
-      expect(payload).toHaveProperty("type", "measure1_Type");
-      expect(payload).toHaveProperty("time");
-    });
+test("Maps message to a custom topic", async () => {
+  const data = await flow.onMessage(
+    {
+      timestamp: tedge.mockGetTime(),
+      topic: "/plant1/line1/device1_measure1_Type",
+      payload: JSON.stringify({
+        value: 100,
+      }),
+    },
+    {
+      targetTopic:
+        "'te/device/' & _TOPIC_LEVEL_[1] & '///m/' & $replace(_TOPIC_LEVEL_[-1], /^[^_]+_/, '')",
+      substitutions: [
+        {
+          pathSource: "value",
+          pathTarget: "output",
+        },
+        {
+          pathSource: "'measure1_Type'",
+          pathTarget: "type",
+        },
+        {
+          pathSource: "$now()",
+          pathTarget: "time",
+        },
+      ],
+    },
+  );
+
+  const payload = JSON.parse(data.payload);
+  expect(data.topic).toBe("te/device/plant1///m/measure1_Type");
+  expect(Object.keys(payload)).toHaveLength(3);
+  expect(payload).toHaveProperty("output", 100);
+  expect(payload).toHaveProperty("type", "measure1_Type");
+  expect(payload).toHaveProperty("time");
+});
+
+test("Maps message to a measurement using targetAPI", async () => {
+  const data = await flow.onMessage(
+    {
+      timestamp: tedge.mockGetTime(),
+      topic: "/plant1/line1/device1_measure1_Type",
+      payload: JSON.stringify({
+        value: 100,
+      }),
+    },
+    {
+      targetAPI: "MEASUREMENT",
+      substitutions: [
+        {
+          pathSource: "_TOPIC_LEVEL_[1]",
+          pathTarget: "_IDENTITY_.externalId",
+        },
+        {
+          pathSource: "value",
+          pathTarget: "output",
+        },
+        {
+          pathSource: "$replace(_TOPIC_LEVEL_[-1], /^[^_]+_/, '')",
+          pathTarget: "type",
+        },
+        {
+          pathSource: "$now()",
+          pathTarget: "time",
+        },
+      ],
+    },
+  );
+
+  const payload = JSON.parse(data.payload);
+  expect(data.topic).toBe("te/device/plant1///m/measure1_Type");
+  expect(Object.keys(payload)).toHaveLength(3);
+  expect(payload).toHaveProperty("output", 100);
+  expect(payload).toHaveProperty("type", "measure1_Type");
+  expect(payload).toHaveProperty("time");
+});
+
+test("Maps message to an event using targetAPI", async () => {
+  const data = await flow.onMessage(
+    {
+      timestamp: tedge.mockGetTime(),
+      topic: "/plant1/line1/device1_measure1_Type",
+      payload: JSON.stringify({
+        value: 100,
+      }),
+    },
+    {
+      targetAPI: "EVENT",
+      substitutions: [
+        {
+          pathSource: "_TOPIC_LEVEL_[1]",
+          pathTarget: "_IDENTITY_.externalId",
+        },
+        {
+          pathSource: "value",
+          pathTarget: "output",
+        },
+        {
+          pathSource: "$replace(_TOPIC_LEVEL_[-1], /^[^_]+_/, '')",
+          pathTarget: "type",
+        },
+        {
+          pathSource: "$now()",
+          pathTarget: "time",
+        },
+      ],
+    },
+  );
+
+  const payload = JSON.parse(data.payload);
+  expect(data.topic).toBe("te/device/plant1///e/measure1_Type");
+  expect(Object.keys(payload)).toHaveLength(3);
+  expect(payload).toHaveProperty("output", 100);
+  expect(payload).toHaveProperty("type", "measure1_Type");
+  expect(payload).toHaveProperty("time");
+});
+
+test("Maps message to an alarm using targetAPI", async () => {
+  const data = await flow.onMessage(
+    {
+      timestamp: tedge.mockGetTime(),
+      topic: "/plant1/line1/device1_measure1_Type",
+      payload: JSON.stringify({
+        value: 100,
+        text: "foo",
+      }),
+    },
+    {
+      targetAPI: "ALARM",
+      substitutions: [
+        {
+          // remove path
+          pathSource: "value",
+          pathTarget: "",
+        },
+        {
+          pathSource: "_TOPIC_LEVEL_[1]",
+          pathTarget: "_IDENTITY_.externalId",
+        },
+        {
+          pathSource: "'major'",
+          pathTarget: "severity",
+        },
+        {
+          pathSource: "$replace(_TOPIC_LEVEL_[-1], /^[^_]+_/, '')",
+          pathTarget: "type",
+        },
+        {
+          pathSource: "$now()",
+          pathTarget: "time",
+        },
+      ],
+    },
+  );
+
+  const payload = JSON.parse(data.payload);
+  expect(data.topic).toBe("te/device/plant1///a/measure1_Type");
+  expect(Object.keys(payload)).toHaveLength(4);
+  expect(payload).toHaveProperty("type", "measure1_Type");
+  expect(payload).toHaveProperty("severity", "major");
+  expect(payload).toHaveProperty("time");
+  expect(payload).toHaveProperty("text", "foo");
+});
+
+test("Maps message to an twin fragment using targetAPI", async () => {
+  const data = await flow.onMessage(
+    {
+      timestamp: tedge.mockGetTime(),
+      topic: "/plant1/line1/prop1",
+      payload: JSON.stringify({
+        os: "Debian",
+        version: "12",
+      }),
+    },
+    {
+      targetAPI: "INVENTORY",
+      substitutions: [
+        {
+          pathSource: "_TOPIC_LEVEL_[1]",
+          pathTarget: "_IDENTITY_.externalId",
+        },
+        {
+          pathSource: "_TOPIC_LEVEL_[-1]",
+          pathTarget: "type",
+        },
+        {
+          pathSource: "$now()",
+          pathTarget: "updatedAt",
+        },
+      ],
+    },
+  );
+
+  const payload = JSON.parse(data.payload);
+  expect(data.topic).toBe("te/device/plant1///twin/prop1");
+  expect(Object.keys(payload)).toHaveLength(4);
+  expect(payload).toHaveProperty("os", "Debian");
+  expect(payload).toHaveProperty("version", "12");
+  expect(payload).toHaveProperty("type", "prop1");
+  expect(payload).toHaveProperty("updatedAt");
 });


### PR DESCRIPTION
Extend the jsonata example to also allow the template to define which topic the data should be sent to.