### PR TITLE
feat: extend ThingsBoard flow to support alarm/event mapping

### DIFF
--- a/flows/thingsboard/README.md
+++ b/flows/thingsboard/README.md
@@ -21,6 +21,11 @@ The flow supports mapping from Thin Edge JSON to the ThingsBoard Gateway API.
     - payload: `{"temperature: 10}`
     - If set to `true`, the converted payload becomes: `{"sensor::temperature": 10}`
 
+- `alarm_prefix`: `<string>`
+- `event_prefix`: `<string>`
+  - To distinguish alarms and events from other data types, the step prepends these prefixes to the type from the MQTT topic to form the telemetry key used by ThingsBoard.
+    Refer to the [alarm example](#alarms---telemetry) and [event example](#events---telemetry) to see how this works (`alarm::` and `event::` respectively).
+
 - If you don't want to add timestamp to telemetry, remove the builtin `add-timestamp` step from `flow.toml`.
 
 ## Setup
@@ -189,9 +194,7 @@ topic: `tb/gateway/telemetry`
 
 topic: `te/device/main///a/temperature_high`
 
-```json
-{}
-```
+empty payload
 
 #### ThingsBoard cleared alarms
 
@@ -200,11 +203,8 @@ topic: `tb/gateway/telemetry`
 ```json
 {
   "MAIN": [
-    "ts": 1602739847000,
-    "values": {
-      "alarm::temperature_high": {
-        "status": "cleared",
-      }
+    "alarm::temperature_high": {
+      "status": "cleared",
     }
   ]
 }

--- a/flows/thingsboard/flow.toml
+++ b/flows/thingsboard/flow.toml
@@ -10,5 +10,7 @@ config.reformat = true
 script = "dist/main.mjs"
 config.main_device_name = "{{MAIN_DEVICE_NAME}}"
 config.add_type_to_key = true
+config.alarm_prefix = "alarm::"
+config.event_prefix = "event::"
 
 errors.mqtt.topic = "te/errors"

--- a/flows/thingsboard/tests/main.test.ts
+++ b/flows/thingsboard/tests/main.test.ts
@@ -250,6 +250,7 @@ describe("Map Alarms to Telemetry", () => {
     const context = tedge.createContext({
       main_device_name: "PROD_GATEWAY",
       add_type_to_key: true,
+      alarm_prefix: "alarm::",
     });
     const output = flow.onMessage(message, context);
     expect(output).toHaveLength(1);
@@ -275,17 +276,16 @@ describe("Map Alarms to Telemetry", () => {
     });
   });
 
-  test("Convert a cleared alarm", () => {
+  test("Convert an empty JSON to an active alarm", () => {
     const message: tedge.Message = {
       time: tedge.mockGetTime(),
       topic: "te/device/main///a/temperature_high",
-      payload: JSON.stringify({
-        time: 1602739847.0,
-      }),
+      payload: JSON.stringify({}),
     };
     const context = tedge.createContext({
       main_device_name: "PROD_GATEWAY",
       add_type_to_key: true,
+      alarm_prefix: "alarm::",
     });
     const output = flow.onMessage(message, context);
     expect(output).toHaveLength(1);
@@ -293,11 +293,33 @@ describe("Map Alarms to Telemetry", () => {
     expect(payload).toStrictEqual({
       PROD_GATEWAY: [
         {
-          ts: 1602739847000,
-          values: {
-            "alarm::temperature_high": {
-              status: "cleared",
-            },
+          "alarm::temperature_high": {
+            status: "active",
+          },
+        },
+      ],
+    });
+  });
+
+  test("Convert a cleared alarm", () => {
+    const message: tedge.Message = {
+      time: tedge.mockGetTime(),
+      topic: "te/device/main///a/temperature_high",
+      payload: "",
+    };
+    const context = tedge.createContext({
+      main_device_name: "PROD_GATEWAY",
+      add_type_to_key: true,
+      alarm_prefix: "alarm::",
+    });
+    const output = flow.onMessage(message, context);
+    expect(output).toHaveLength(1);
+    const payload = JSON.parse(output[0].payload);
+    expect(payload).toStrictEqual({
+      PROD_GATEWAY: [
+        {
+          "alarm::temperature_high": {
+            status: "cleared",
           },
         },
       ],
@@ -323,7 +345,7 @@ describe("Map Alarms to Telemetry", () => {
     expect(payload).toStrictEqual({
       PROD_GATEWAY: [
         {
-          "alarm::temperature_high": {
+          temperature_high: {
             status: "active",
             severity: "major",
             text: "Temperature is very high",
@@ -352,6 +374,7 @@ describe("Map Events to Telemetry", () => {
     const context = tedge.createContext({
       main_device_name: "PROD_GATEWAY",
       add_type_to_key: true,
+      event_prefix: "event::",
     });
     const output = flow.onMessage(message, context);
     expect(output).toHaveLength(1);
@@ -393,7 +416,7 @@ describe("Map Events to Telemetry", () => {
     expect(payload).toStrictEqual({
       PROD_GATEWAY: [
         {
-          "event::login_event": {
+          login_event: {
             text: "A user just logged in",
           },
         },


### PR DESCRIPTION
Support conversion from thin-edge.io alarm/event to ThingsBoard telemetry.

Unfortunately, alarms cannot be created via MQTT on ThingsBoard. They offer [REST API](https://demo.thingsboard.io/swagger-ui/index.html#/alarm-controller/saveAlarm) or rules that raises an alarm based on telemetry. For more info about ThingsBoard alarms, refer to [here](https://thingsboard.io/docs/user-guide/alarms/).

Also, their concepts for events seems very different from thin-edge.io.

For the conversion, I decided to use the telemetry endpoint for alarm and event mapping. Some notes for the mapping rules:
* **status (for alarms)**: ThingsBoard has 4 states (active/cleared * acknowledged/unacknowledged), whilst thin-edge.io has only two (active/cleared). I ignore the acknowledge state because I believe the state is for users on UI.
* **prefix `alarm::` / `event::`**: To distinguish alarms/events from other data, the step ~~forces to~~ can add a special prefix to the type from the MQTT topic.
* **time**: If user disables `add-timestamp` step and `time` key is not provided in the input, do not add it. This indicates user wants to use the server time.