### PR TITLE
refactor: change default flow location to include flow name

### DIFF
--- a/flows/certificate-alert/flow.toml
+++ b/flows/certificate-alert/flow.toml
@@ -3,7 +3,7 @@ command = """sh -c \"tedge cert show | tr '\\n' '\\0'\""""
 interval = "600s"
 
 [[steps]]
-script = "dist/flow.mjs"
+script = "certificate-alert/dist/flow.mjs"
 
 # turn on additional debugging
 debug = false

--- a/flows/cloud-mapper-commands/flow.toml
+++ b/flows/cloud-mapper-commands/flow.toml
@@ -5,7 +5,7 @@ mqtt.topics = [
 ]
 
 [[steps]]
-script = "dist/main.mjs"
+script = "cloud-mapper-commands/dist/main.mjs"
 config.cloud_prefix = "azeg"
 
 # List of commands which should be mapped from the cloud to tedge topics

--- a/flows/cloud-mapper-telemetry/flow.toml
+++ b/flows/cloud-mapper-telemetry/flow.toml
@@ -4,6 +4,6 @@ mqtt.topics = [
 ]
 
 [[steps]]
-script = "dist/main.mjs"
+script = "cloud-mapper-telemetry/dist/main.mjs"
 config.cloud_topic_prefix = "azeg/DDATA"
 config.pretty_print = false

--- a/flows/jsonata-xform/flow.toml
+++ b/flows/jsonata-xform/flow.toml
@@ -4,7 +4,7 @@ mqtt.topics = [
 ]
 
 [[steps]]
-script = "dist/main.mjs"
+script = "jsonata-xform/dist/main.mjs"
 [[steps.config.substitutions]]
 pathSource = "$replace(dateTo,' ','T')"
 pathTarget = "dateTo"

--- a/flows/log-surge/flow.toml
+++ b/flows/log-surge/flow.toml
@@ -9,7 +9,7 @@ command = """sudo journalctl -o json -b --cursor-file=/tmp/log-surge-cursor --no
 interval = "300s"
 
 [[steps]]
-script = "dist/main.mjs"
+script = "log-surge/dist/main.mjs"
 interval = "600s"
 
 config.with_logs = false

--- a/flows/protobuf-xform/flow.toml
+++ b/flows/protobuf-xform/flow.toml
@@ -6,7 +6,7 @@ mqtt.topics = [
 ]
 
 [[steps]]
-script = "dist/main.mjs"
+script = "protobuf-xform/dist/main.mjs"
 # config.topic: Use the template variable, '{{type}}' if you wish to include the sensor data type within the topic
 config.topic = "c8y-mqtt/proto/sensor_data"
 config.cmdtopic = "te/device/main///sig/setpoint"

--- a/flows/thingsboard/flow.toml
+++ b/flows/thingsboard/flow.toml
@@ -7,7 +7,7 @@ config.format = "unix"
 config.reformat = true
 
 [[steps]]
-script = "dist/main.mjs"
+script = "thingsboard/dist/main.mjs"
 config.main_device_name = "{{MAIN_DEVICE_NAME}}"
 config.add_type_to_key = true
 config.alarm_prefix = "alarm::"

--- a/flows/uptime/flow.toml
+++ b/flows/uptime/flow.toml
@@ -5,7 +5,7 @@ mqtt.topics = [
 ]
 
 [[steps]]
-script = "dist/main.mjs"
+script = "uptime/dist/main.mjs"
 interval = "10s"
 config.window_size_minutes = 1440
 config.stats_topic = "twin/onlineTracker"

--- a/scripts/create-flow.js
+++ b/scripts/create-flow.js
@@ -43,7 +43,7 @@ mqtt.topics = [
 ]
 
 [[steps]]
-script = "dist/main.mjs"
+script = "${projectName}/dist/main.mjs"
 config.debug = 1440
 config.custom_prop = "my/prop"
 `.trimStart();


### PR DESCRIPTION
Change default flow location to include flow name

Workaround until relative addressing (relative to the flow definition)  is supported by the flows engine.