### PR TITLE
ci: support building local tarballs in additional to optionally publishing to a registry

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -75,4 +75,10 @@ jobs:
         run: go install github.com/thin-edge/tedge-oscar@latest
 
       - name: Publish
-        run: npm run publish
+        run: npm run publish -- --target registry
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: flows
+          path: ./dist/*.tar.gz

--- a/scripts/publish-images.js
+++ b/scripts/publish-images.js
@@ -2,25 +2,74 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { parseArgs } = require("node:util");
+
+// arg parsing
+const { positionals: flows, values: args } = parseArgs({
+  options: {
+    help: {
+      type: "boolean",
+      short: "h",
+      default: false,
+    },
+    // Targets where the flow should be published to: only supports 'registry'
+    target: {
+      type: "string",
+      default: "",
+    },
+  },
+  allowPositionals: true,
+});
+
+if (args.help) {
+  console.log(`
+  Usage: node publish-images.js [options] [flows...]
+
+  Options:
+    -h, --help          Show this help message
+    --target TARGET     Comma-separated list of publish targets (e.g., 'registry')
+
+  Arguments:
+    flows               Optional flow directory names to publish (defaults to all workspaces)
+
+  Examples:
+    node publish-images.js
+    node publish-images.js --target registry
+    node publish-images.js flow1 flow2
+    node publish-images.js --target registry flow1 flow2
+
+  Environment Variables:
+    REGISTRY            Container registry URL (default: ghcr.io)
+    OWNER               Registry owner/namespace (default: thin-edge)
+  `);
+  process.exit(0);
+}
+
+const publishToRegistry = args.target
+  .split(",")
+  .map((v) => v.trim())
+  .includes("registry");
+console.log(`publishToRegistry: ${publishToRegistry}`);
 
 const flowFilename = "flow.toml";
 const registry = process.env.REGISTRY || "ghcr.io";
 const owner = process.env.OWNER || "thin-edge";
 
 let workspaces = "--workspaces";
-if (process.argv.length > 2) {
-  workspaces = process.argv
-    .slice(2)
-    .map((value) => `-w ${path.basename(value)}`)
-    .join(" ");
+if (flows.length > 0) {
+  workspaces = flows.map((value) => `-w ${path.basename(value)}`).join(" ");
 }
 
 const projects = JSON.parse(
-  execSync(`npm pkg get ${workspaces} name version module`),
+  execSync(`npm pkg get ${workspaces} name version module tedge`),
 );
 
 // create temp folder to used during packaging
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "flow-builder"));
+
+const outputDir = "./dist";
+fs.rmSync(outputDir, { recursive: true, force: true });
+fs.mkdirSync(outputDir, { recursive: true });
 
 for (const [_, project] of Object.entries(projects)) {
   const sourceProjectDir = `flows/${project.name}`;
@@ -37,19 +86,42 @@ for (const [_, project] of Object.entries(projects)) {
     fs.writeFileSync(
       flowFile,
       [
-        `# name = "${project.name}"`,
-        `# version = "${project.version || "0.0.0"}"\n`,
+        `name = "${project.name}"`,
+        `version = "${project.version || "0.0.0"}"\n`,
         contents,
       ].join("\n"),
     );
 
-    const image = `${registry}/${owner}/${project.name}:${project.version}`;
-    console.log(
-      `\nPublishing flow. project=${project.name}, version=${project.version}, module=${project.module}`,
-    );
+    // Which mapper the flow is designed for
+    let mapper = "local";
+    if (project.tedge && project.tedge.mapper) {
+      mapper = project.tedge.mapper;
+    }
+    console.info("project:", project);
+
+    // Create tar file with flow.toml and built module files, but replace '/' with %2F (url encoding)
+    const tarFileName = mapper
+      ? `${mapper}%2F${project.name}_${project.version}.tar.gz`
+      : `${project.name}_${project.version}.tar.gz`;
+    const tarFilePath = path.join(outputDir, tarFileName);
+    console.log(`Creating tar file: ${tarFileName}`);
+
     execSync(
-      `tedge-oscar flows images push ${image} --file ${projectDir}/${project.module} --file ${projectDir}/${flowFilename} --root ${projectDir}`,
+      `tar -czf ${tarFilePath} -C ${projectDir} ${flowFilename} ${project.module}`,
+      { stdio: "inherit", env: { COPYFILE_DISABLE: 1 } },
     );
+
+    console.log(`Created tar file at: ${tarFilePath}`);
+
+    if (publishToRegistry) {
+      const image = `${registry}/${owner}/${project.name}:${project.version}`;
+      console.log(
+        `\nPublishing flow. image=${image}, project=${project.name}, version=${project.version}, module=${project.module}`,
+      );
+      execSync(
+        `tedge-oscar flows images push ${image} --file ${projectDir}/${project.module} --file ${projectDir}/${flowFilename} --root ${projectDir}`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Extend the publish-images.js script to require explicitly setting the publish target (i.e. where to publish the artifacts to). The existing github workflow is still publishing the flows to the container registry as it did before, but the difference is running `npm run publish` won't publish it to the registry unless you specify, `npm run publish -- --target registry`.

It will also now build a local tarbal file which can be retrieved from the `./dist` folder.