### PR TITLE
feat: add tedge.mapper property to package.json

### DIFF
--- a/flows/certificate-alert/package.json
+++ b/flows/certificate-alert/package.json
@@ -9,6 +9,9 @@
     "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
     "test": "jest --coverageProvider=v8 --coverage"
   },
+  "tedge": {
+    "mapper": "local"
+  },
   "author": "thin-edge.io",
   "license": "Apache-2.0"
 }

--- a/flows/jsonata-xform/package.json
+++ b/flows/jsonata-xform/package.json
@@ -9,6 +9,9 @@
     "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
     "test": "jest --coverageProvider=v8 --coverage"
   },
+  "tedge": {
+    "mapper": "local"
+  },
   "author": "thin-edge.io",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/flows/log-surge/package.json
+++ b/flows/log-surge/package.json
@@ -9,6 +9,9 @@
     "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
     "test": "jest --coverageProvider=v8 --coverage"
   },
+  "tedge": {
+    "mapper": "local"
+  },
   "author": "thin-edge.io",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/flows/protobuf-xform/package.json
+++ b/flows/protobuf-xform/package.json
@@ -10,6 +10,9 @@
     "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
     "test": "jest --coverageProvider=v8 --coverage"
   },
+  "tedge": {
+    "mapper": "local"
+  },
   "author": "thin-edge.io",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/flows/uptime/package.json
+++ b/flows/uptime/package.json
@@ -9,6 +9,9 @@
     "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
     "test": "jest --coverageProvider=v8 --coverage"
   },
+  "tedge": {
+    "mapper": "local"
+  },
   "author": "thin-edge.io",
   "license": "Apache-2.0"
 }

--- a/scripts/create-flow.js
+++ b/scripts/create-flow.js
@@ -18,6 +18,9 @@ const packageTemplate = {
   source: "src/main.ts",
   module: "lib/main.js",
   type: "module",
+  tedge: {
+    mapper: "local",
+  },
   scripts: {
     build:
       "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",


### PR DESCRIPTION
Flows can be identified to which mapper they should be deployed to in the package.json file. This information is only used when building the tarball file.

For now, the other flows which are related to connectivity to other clouds (not c8y, aws or az) don't have an explicit marker to avoid confusion.