### PR TITLE
chore: fix release-please token to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,12 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT or GitHub App token so that release-please PRs trigger
+          # CI workflows. PRs opened by GITHUB_TOKEN are intentionally blocked
+          # from triggering other workflows by GitHub.
+          # Create a fine-grained PAT with Contents + Pull requests (read/write)
+          # and store it as the RELEASE_PLEASE_TOKEN repo secret.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Use a secret from github (if available) to trigger the github actions to ensure that the PR checks will run automatically