### PR TITLE
feat(protobuf-xform): Use clientID when setting the device target in the cloud

### DIFF
--- a/flows/protobuf-xform/src/main-cloud.ts
+++ b/flows/protobuf-xform/src/main-cloud.ts
@@ -19,9 +19,6 @@ export function onMessage(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   context: any,
 ): CumulocityMessage[] {
-  // FIXME: replace with external id and read it from the topic
-  const sourceId = context?.config?.sourceId ?? "1047626587";
-
   let sensorMessage;
   try {
     sensorMessage = fromBinary(SensorMessageSchema, message.payload);
@@ -39,7 +36,6 @@ export function onMessage(
 
     const payload: any = {
       time,
-      source: { id: sourceId },
       type: "c8y_EnvironmentSensor",
       c8y_Temperature: {
         T: { value: env.temperature, unit: "°C" },
@@ -66,7 +62,6 @@ export function onMessage(
 
     const payload: any = {
       time,
-      source: { id: sourceId },
       type: "c8y_LocationUpdate",
       text: "Location Update",
       c8y_Position: {


### PR DESCRIPTION
The cloud now supports reading the device's c8y_Serial from the clientID so it no longer needs a hard coded source id.