### PR TITLE
feat: add new tedge-events flow

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -9,5 +9,6 @@
   "flows/thingsboard-registration": "0.1.0",
   "flows/thingsboard-server-rpc": "0.1.0",
   "flows/uptime": "1.3.0",
-  "flows/tedge-config-context": "1.0.0"
+  "flows/tedge-config-context": "1.0.0",
+  "flows/tedge-events": "0.0.1"
 }

--- a/flows/tedge-events/README.md
+++ b/flows/tedge-events/README.md
@@ -1,0 +1,26 @@
+## tedge-events
+
+Demonstrates how to forward thin-edge.io telemetry data to the Cumulocity MQTT service. Currently supports **events** only.
+
+### Description
+
+The flow subscribes to all thin-edge.io event topics (`te/+/+/+/+/e/+`) and transforms each incoming message into a Cumulocity-compatible event payload before publishing it to the Cumulocity MQTT service.
+
+For each event message the flow:
+
+1. Extracts the event type from the last segment of the input topic (e.g. `myEvent` from `te/device/main///e/myEvent`).
+2. Reads the `device.id` from the shared flow context (populated by the `tedge-config-context` flow) and uses it as the event `source`.
+3. Attaches a monotonically incrementing `tedgeSequence` counter to each outgoing message for ordering/deduplication.
+4. Appends `" (from mqtt-service)"` to the event `text` field (or uses `"test event"` as the default if no `text` was provided).
+5. Publishes the enriched payload to the configured output topic (default: `c8y/mqtt/out/te/v1/events`).
+
+### Configuration
+
+| Parameter             | Default                     | Description                                                    |
+| --------------------- | --------------------------- | -------------------------------------------------------------- |
+| `output_events_topic` | `c8y/mqtt/out/te/v1/events` | MQTT topic where transformed events are published              |
+| `debug`               | `false`                     | When `true`, logs each incoming message payload to the console |
+
+### Related flows
+
+- **tedge-config-context** — populates `device.id` in the shared mapper context used by this flow as the event `source`.

--- a/flows/tedge-events/flow.toml
+++ b/flows/tedge-events/flow.toml
@@ -1,0 +1,9 @@
+[input.mqtt]
+topics = ["te/+/+/+/+/e/+"]
+
+[config]
+debug = "${.params.debug}"
+output_events_topic = "${.params.output_events_topic}"
+
+[[steps]]
+script = "lib/main.js"

--- a/flows/tedge-events/package.json
+++ b/flows/tedge-events/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tedge-events",
+  "version": "0.0.1",
+  "description": "Forward thin-edge.io events to the Cumulocity MQTT service",
+  "source": "src/main.ts",
+  "module": "lib/main.js",
+  "type": "module",
+  "tedge": {
+    "mapper": "local"
+  },
+  "scripts": {
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "test": "jest --coverageProvider=v8 --coverage"
+  },
+  "author": "thin-edge.io",
+  "license": "Apache-2.0"
+}

--- a/flows/tedge-events/params.toml.template
+++ b/flows/tedge-events/params.toml.template
@@ -1,0 +1,5 @@
+# enable debug messages
+debug = false
+
+# topic where the messages will be written to
+output_events_topic = "c8y/mqtt/out/te/v1/events"

--- a/flows/tedge-events/src/main.ts
+++ b/flows/tedge-events/src/main.ts
@@ -1,0 +1,46 @@
+import { Message, Context, decodeJsonPayload } from "../../common/tedge";
+
+export interface Config {
+  debug?: boolean;
+  output_events_topic?: string;
+}
+
+export interface FlowContext extends Context {
+  config: Config;
+}
+
+export function onMessage(message: Message, context: FlowContext) {
+  const messageType = message.topic.split("/").slice(-1)[0];
+
+  // read device.id from the mapper context (if available)
+  const source = context.mapper.get("device.id") ?? "";
+
+  const { output_events_topic = "c8y/mqtt/out/te/v1/events", debug = false } =
+    context.config;
+
+  // use a sequence counter
+  const seq = context.script.get("seq") || 1;
+  context.script.set("seq", seq + 1);
+
+  const payload = decodeJsonPayload(message.payload);
+
+  if (debug) {
+    console.log(`Processing message`, { payload });
+  }
+
+  // remove the text from the payload
+  const { text, ...properties } = payload;
+  return [
+    {
+      topic: output_events_topic,
+      payload: JSON.stringify({
+        ...properties,
+        text: `${text || "test event"} (from mqtt-service)`,
+        tedgeSequence: seq,
+        type: messageType,
+        payloadType: "event",
+        source,
+      }),
+    },
+  ];
+}

--- a/flows/tedge-events/tests/main.test.ts
+++ b/flows/tedge-events/tests/main.test.ts
@@ -1,0 +1,122 @@
+import { expect, test, describe } from "@jest/globals";
+import * as tedge from "../../common/tedge";
+import * as flow from "../src/main";
+
+describe("map messages", () => {
+  test.each([
+    {
+      description: "event with text field",
+      topic: "te/device/main///e/myEvent",
+      inputPayload: { text: "door opened", temperature: 22.5 },
+      config: {},
+      contextMapper: {},
+      expectedTopic: "c8y/mqtt/out/te/v1/events",
+      expectedPayload: {
+        temperature: 22.5,
+        text: "door opened (from mqtt-service)",
+        tedgeSequence: 1,
+        type: "myEvent",
+        payloadType: "event",
+        source: "",
+      },
+    },
+    {
+      description: "event without text uses default",
+      topic: "te/device/main///e/restart",
+      inputPayload: { reason: "ota" },
+      config: {},
+      contextMapper: {},
+      expectedTopic: "c8y/mqtt/out/te/v1/events",
+      expectedPayload: {
+        reason: "ota",
+        text: "test event (from mqtt-service)",
+        tedgeSequence: 1,
+        type: "restart",
+        payloadType: "event",
+        source: "",
+      },
+    },
+    {
+      description: "device.id from mapper context is used as source",
+      topic: "te/device/main///e/myEvent",
+      inputPayload: { text: "motion detected" },
+      config: {},
+      contextMapper: { "device.id": "my-device" },
+      expectedTopic: "c8y/mqtt/out/te/v1/events",
+      expectedPayload: {
+        text: "motion detected (from mqtt-service)",
+        tedgeSequence: 1,
+        type: "myEvent",
+        payloadType: "event",
+        source: "my-device",
+      },
+    },
+    {
+      description: "custom output_events_topic from config",
+      topic: "te/device/main///e/alarm",
+      inputPayload: { text: "high temp" },
+      config: { output_events_topic: "custom/events/out" },
+      contextMapper: {},
+      expectedTopic: "custom/events/out",
+      expectedPayload: {
+        text: "high temp (from mqtt-service)",
+        tedgeSequence: 1,
+        type: "alarm",
+        payloadType: "event",
+        source: "",
+      },
+    },
+  ])(
+    "$description",
+    ({
+      topic,
+      inputPayload,
+      config,
+      contextMapper,
+      expectedTopic,
+      expectedPayload,
+    }) => {
+      const context = tedge.createContext(config);
+      for (const [k, v] of Object.entries(contextMapper)) {
+        context.mapper.set(k, v);
+      }
+
+      const output = flow.onMessage(
+        {
+          time: new Date("2026-01-01"),
+          topic,
+          payload: JSON.stringify(inputPayload),
+        },
+        context,
+      );
+
+      expect(output).toHaveLength(1);
+      expect(output[0].topic).toBe(expectedTopic);
+      const payload = tedge.decodeJsonPayload(output[0].payload);
+      expect(payload).toMatchObject(expectedPayload);
+    },
+  );
+
+  test("sequence counter increments with each message", () => {
+    const context = tedge.createContext({});
+    const msg = {
+      time: new Date("2026-01-01"),
+      topic: "te/device/main///e/myEvent",
+      payload: JSON.stringify({ text: "ping" }),
+    };
+
+    const first = tedge.decodeJsonPayload(
+      flow.onMessage(msg, context)[0].payload,
+    );
+    const second = tedge.decodeJsonPayload(
+      flow.onMessage(msg, context)[0].payload,
+    );
+    const third = tedge.decodeJsonPayload(
+      flow.onMessage(msg, context)[0].payload,
+    );
+
+    expect(first.tedgeSequence).toBe(1);
+    expect(second.tedgeSequence).toBe(2);
+    expect(third.tedgeSequence).toBe(3);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
       "license": "ISC"
     },
     "flows/tedge-config-context": {
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -588,6 +588,10 @@
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
       }
+    },
+    "flows/tedge-events": {
+      "version": "0.0.1",
+      "license": "Apache-2.0"
     },
     "flows/thingsboard": {
       "version": "0.1.0",
@@ -6438,6 +6442,10 @@
     },
     "node_modules/tedge-config-context": {
       "resolved": "flows/tedge-config-context",
+      "link": true
+    },
+    "node_modules/tedge-events": {
+      "resolved": "flows/tedge-events",
       "link": true
     },
     "node_modules/test-exclude": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,9 @@
     },
     "flows/tedge-config-context": {
       "component": "tedge-config-context"
+    },
+    "flows/tedge-events": {
+      "component": "tedge-events"
     }
   }
 }


### PR DESCRIPTION
The flow maps thin-edge.io events to the Cumulocity MQTT Service and the data is enriched with additional properties, though technically users can map the data to any MQTT topic (not just to the Cumulocity mqtt-service)