### PR TITLE
fix(tedge-config-context): remove duplicate meta information

### DIFF
--- a/flows/tedge-config-context/flow.toml
+++ b/flows/tedge-config-context/flow.toml
@@ -1,7 +1,3 @@
-name = "tedge-config-context"
-version = "0.0.1"
-description = "Add configuration to the context so it is accessible for other flows"
-
 [input.process]
 command = "tedge config list"
 interval = "600s"


### PR DESCRIPTION
Remove meta information from the flow definition as this is added automatically at build time.

Previously this was causing the built flow to have duplicate keys which would prevent the flow from being loaded.