### PR TITLE
feat: create a params.toml.template file when creating a new flow

### DIFF
--- a/scripts/create-flow.js
+++ b/scripts/create-flow.js
@@ -51,6 +51,11 @@ config.debug = 1440
 config.custom_prop = "my/prop"
 `.trimStart();
 
+const templateParamsTemplate = `
+# enable debug messages
+debug = false
+`.trimStart();
+
 const templateREADME = `
 ## ${projectName}
 
@@ -138,6 +143,10 @@ function generateProject(name) {
     JSON.stringify(packageTemplate, null, "  "),
   );
   fs.writeFileSync(path.join(projectDir, "flow.toml"), templateFlow);
+  fs.writeFileSync(
+    path.join(projectDir, "params.toml.template"),
+    templateParamsTemplate,
+  );
   fs.writeFileSync(path.join(projectDir, "README.md"), templateREADME);
 
   fs.mkdirSync(path.join(projectDir, "src"));


### PR DESCRIPTION
Create a placeholder `params.toml.template` file when using `npm run generate-flow`.