### PR TITLE
feat: add tedge-measurement-batch flow to process batched JSON measurements

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,5 +10,6 @@
   "flows/thingsboard-server-rpc": "0.1.0",
   "flows/uptime": "1.3.0",
   "flows/tedge-config-context": "1.0.1",
-  "flows/tedge-events": "0.1.0"
+  "flows/tedge-events": "0.1.0",
+  "flows/tedge-measurement-batch": "0.0.1"
 }

--- a/flows/tedge-measurement-batch/README.md
+++ b/flows/tedge-measurement-batch/README.md
@@ -1,0 +1,51 @@
+## tedge-measurement-batch
+
+Split batched ThinEdge JSON measurement payloads into individual messages.
+
+### Description
+
+Some systems publish multiple measurements in a single MQTT message as a JSON
+array rather than individual JSON objects. The thin-edge.io mapper only
+accepts single-object payloads, so this flow acts as a pre-processing step
+that transparently converts batch payloads into a stream of individual
+measurement messages.
+
+The flow processes messages as follows:
+
+1. Subscribe to all `te/+/+/+/+/m/+` measurement topics.
+2. If the payload is a **JSON array**, emit one message per element on the
+   same topic. Each element that lacks a `time` field is automatically
+   stamped with the message receive time.
+3. If the payload is a **JSON object** (already a single measurement), emit
+   nothing — the built-in thin-edge.io flow handles it without interference.
+
+### Example
+
+**Input** – one message with a batched payload:
+
+```
+topic:   te/device/main///m/env
+payload: [
+  {"time": "2020-10-15T05:30:47+00:00", "temperature": 25},
+  {"time": "2020-10-15T05:30:48+00:00", "temperature": 26},
+  {"location": {"latitude": 32.54, "longitude": -117.67, "altitude": 98.6}}
+]
+```
+
+**Output** – three individual messages (all on the same topic):
+
+```
+{"time": "2020-10-15T05:30:47+00:00", "temperature": 25}
+{"time": "2020-10-15T05:30:48+00:00", "temperature": 26}
+{"time": "<receive-time>", "location": {"latitude": 32.54, "longitude": -117.67, "altitude": 98.6}}
+```
+
+### Parameters
+
+| Parameter | Type    | Default | Description                         |
+| --------- | ------- | ------- | ----------------------------------- |
+| `debug`   | boolean | `false` | Log each received message to stdout |
+
+### References
+
+- thin-edge.io issue [#3613](https://github.com/thin-edge/thin-edge.io/issues/3613) – Support batching ThinEdge JSON

--- a/flows/tedge-measurement-batch/flow.toml
+++ b/flows/tedge-measurement-batch/flow.toml
@@ -1,0 +1,17 @@
+
+# message are sent back on the same input topic, however
+# as the flow only processes messages with an array of items
+# there isn't an infinite loop.
+expect_loop = true
+
+[input.mqtt]
+# Subscribe to all thin-edge.io measurement topics.
+# Devices may publish either a single measurement object or a JSON array of
+# measurement objects (a "batch").  This flow transparently splits batches
+# into individual messages so the rest of the pipeline sees only single-object
+# payloads.
+topics = ["te/+/+/+/+/m/+"]
+
+[[steps]]
+script = "lib/main.js"
+config.debug = "${.params.debug}"

--- a/flows/tedge-measurement-batch/package.json
+++ b/flows/tedge-measurement-batch/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tedge-measurement-batch",
+  "version": "0.0.1",
+  "description": "Flow description",
+  "source": "src/main.ts",
+  "module": "lib/main.js",
+  "type": "module",
+  "tedge": {
+    "mapper": "c8y"
+  },
+  "scripts": {
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "test": "jest --coverageProvider=v8 --coverage"
+  },
+  "author": "thin-edge.io",
+  "license": "Apache-2.0"
+}

--- a/flows/tedge-measurement-batch/params.toml.template
+++ b/flows/tedge-measurement-batch/params.toml.template
@@ -1,0 +1,2 @@
+# enable debug messages
+debug = false

--- a/flows/tedge-measurement-batch/src/main.ts
+++ b/flows/tedge-measurement-batch/src/main.ts
@@ -1,0 +1,45 @@
+import { Message, Context, decodeJsonPayload } from "../../common/tedge";
+
+export interface Config {
+  debug?: boolean;
+}
+
+export interface FlowContext extends Context {
+  config: Config;
+}
+
+/**
+ * Split a batched ThinEdge JSON measurement payload (an array of measurement
+ * objects) into individual messages, one per array element.  If an element
+ * does not include a "time" field the message's receive time is used as a
+ * fallback so that every outgoing message is always timestamped.
+ *
+ * Non-array payloads are ignored (empty output) so the built-in thin-edge.io
+ * flow handles them without interference.
+ */
+export function onMessage(message: Message, context: FlowContext): Message[] {
+  const { debug = false } = context.config;
+
+  const payload = decodeJsonPayload(message.payload);
+
+  if (debug) {
+    console.log("Received message", { topic: message.topic, payload });
+  }
+
+  // Non-array payloads are not batched – drop them so the built-in
+  // thin-edge.io flow handles them without interference.
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  const fallbackTime = message.time.toISOString();
+
+  return payload.map((item) => ({
+    time: item.time ? new Date(item.time) : message.time,
+    topic: message.topic,
+    payload: JSON.stringify({
+      time: fallbackTime,
+      ...item,
+    }),
+  }));
+}

--- a/flows/tedge-measurement-batch/tests/main.test.ts
+++ b/flows/tedge-measurement-batch/tests/main.test.ts
@@ -1,0 +1,153 @@
+import { expect, test, describe } from "@jest/globals";
+import * as tedge from "../../common/tedge";
+import * as flow from "../src/main";
+
+const RECEIVE_TIME = new Date("2020-10-15T06:00:00.000Z");
+
+describe("batched measurements", () => {
+  test("splits a batch of two measurements into two messages", () => {
+    const inputPayload = [
+      { time: "2020-10-15T05:30:47+00:00", temperature: 25 },
+      { time: "2020-10-15T05:30:48+00:00", temperature: 26 },
+    ];
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic: "te/device/main///m/env",
+        payload: JSON.stringify(inputPayload),
+      },
+      tedge.createContext({}),
+    );
+
+    expect(output).toHaveLength(2);
+
+    const p0 = tedge.decodeJsonPayload(output[0].payload);
+    expect(output[0].topic).toBe("te/device/main///m/env");
+    expect(p0).toMatchObject({
+      temperature: 25,
+      time: "2020-10-15T05:30:47+00:00",
+    });
+
+    const p1 = tedge.decodeJsonPayload(output[1].payload);
+    expect(output[1].topic).toBe("te/device/main///m/env");
+    expect(p1).toMatchObject({
+      temperature: 26,
+      time: "2020-10-15T05:30:48+00:00",
+    });
+  });
+
+  test("fills in receive-time when item has no time field", () => {
+    const inputPayload = [{ temperature: 25 }, { temperature: 26 }];
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic: "te/device/main///m/env",
+        payload: JSON.stringify(inputPayload),
+      },
+      tedge.createContext({}),
+    );
+
+    expect(output).toHaveLength(2);
+    const p0 = tedge.decodeJsonPayload(output[0].payload);
+    expect(p0.time).toBe(RECEIVE_TIME.toISOString());
+    const p1 = tedge.decodeJsonPayload(output[1].payload);
+    expect(p1.time).toBe(RECEIVE_TIME.toISOString());
+  });
+
+  test("item-level time overrides fallback time", () => {
+    const itemTime = "2020-10-15T05:30:47+00:00";
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic: "te/device/main///m/env",
+        payload: JSON.stringify([{ time: itemTime, temperature: 25 }]),
+      },
+      tedge.createContext({}),
+    );
+
+    const p = tedge.decodeJsonPayload(output[0].payload);
+    expect(p.time).toBe(itemTime);
+  });
+
+  test("handles a batch with mixed time / no-time items", () => {
+    const inputPayload = [
+      { time: "2020-10-15T05:30:47+00:00", temperature: 25 },
+      { temperature: 26 },
+      {
+        location: { latitude: 32.54, longitude: -117.67, altitude: 98.6 },
+      },
+    ];
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic: "te/device/main///m/location",
+        payload: JSON.stringify(inputPayload),
+      },
+      tedge.createContext({}),
+    );
+
+    expect(output).toHaveLength(3);
+
+    const p0 = tedge.decodeJsonPayload(output[0].payload);
+    expect(p0.time).toBe("2020-10-15T05:30:47+00:00");
+    expect(p0.temperature).toBe(25);
+
+    const p1 = tedge.decodeJsonPayload(output[1].payload);
+    expect(p1.time).toBe(RECEIVE_TIME.toISOString());
+    expect(p1.temperature).toBe(26);
+
+    const p2 = tedge.decodeJsonPayload(output[2].payload);
+    expect(p2.location).toEqual({
+      latitude: 32.54,
+      longitude: -117.67,
+      altitude: 98.6,
+    });
+  });
+
+  test("preserves the original topic for every output message", () => {
+    const topic = "te/device/child001///m/sensor";
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic,
+        payload: JSON.stringify([{ value: 1 }, { value: 2 }]),
+      },
+      tedge.createContext({}),
+    );
+
+    output.forEach((msg) => expect(msg.topic).toBe(topic));
+  });
+});
+
+describe("single (non-batched) measurements", () => {
+  test("returns no messages for a single-object payload (handled by built-in flow)", () => {
+    const singlePayload = {
+      time: "2020-10-15T05:30:47+00:00",
+      temperature: 25,
+    };
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic: "te/device/main///m/env",
+        payload: JSON.stringify(singlePayload),
+      },
+      tedge.createContext({}),
+    );
+
+    expect(output).toHaveLength(0);
+  });
+});
+
+describe("empty batch", () => {
+  test("returns no messages for an empty array", () => {
+    const output = flow.onMessage(
+      {
+        time: RECEIVE_TIME,
+        topic: "te/device/main///m/env",
+        payload: JSON.stringify([]),
+      },
+      tedge.createContext({}),
+    );
+    expect(output).toHaveLength(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
       "license": "ISC"
     },
     "flows/tedge-config-context": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -590,6 +590,10 @@
       }
     },
     "flows/tedge-events": {
+      "version": "0.1.0",
+      "license": "Apache-2.0"
+    },
+    "flows/tedge-measurement-batch": {
       "version": "0.0.1",
       "license": "Apache-2.0"
     },
@@ -6446,6 +6450,10 @@
     },
     "node_modules/tedge-events": {
       "resolved": "flows/tedge-events",
+      "link": true
+    },
+    "node_modules/tedge-measurement-batch": {
+      "resolved": "flows/tedge-measurement-batch",
       "link": true
     },
     "node_modules/test-exclude": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,6 +37,9 @@
     },
     "flows/tedge-events": {
       "component": "tedge-events"
+    },
+    "flows/tedge-measurement-batch": {
+      "component": "tedge-measurement-batch"
     }
   }
 }


### PR DESCRIPTION
New flow to process batched thin-edge.io measurements by splitting an array of measurements into individual messages which are then processed by the default measurement flow.

Resolves https://github.com/thin-edge/thin-edge.io/issues/3613