### PR TITLE
feat: add measurement aggregator

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,6 +4,7 @@
   "flows/cloud-mapper-telemetry": "0.1.0",
   "flows/jsonata-xform": "0.1.0",
   "flows/log-surge": "1.4.0",
+  "flows/measurement-aggregator": "0.0.1",
   "flows/protobuf-xform": "0.2.1",
   "flows/thingsboard": "0.1.0",
   "flows/thingsboard-registration": "0.1.0",

--- a/flows/measurement-aggregator/README.md
+++ b/flows/measurement-aggregator/README.md
@@ -1,0 +1,93 @@
+## measurement-aggregator
+
+Collect individual per-topic MQTT datapoints and emit them together as a single aggregated [thin-edge.io measurement](https://thin-edge.github.io/thin-edge.io/references/mqtt-api/#telemetry-data).
+
+### Problem
+
+Many data sources publish one MQTT message per data point, each to a separate topic:
+
+```
+sensors/temperature  →  23.5
+sensors/humidity     →  60
+sensors/pressure     →  1013.25
+```
+
+Sending these as three individual measurements to Cumulocity IoT creates three separate data rows in the platform. This flow collects them within a configurable time window and flushes them as one combined measurement:
+
+```json
+{
+  "time": "2024-06-01T12:00:00.000Z",
+  "temperature": 23.5,
+  "humidity": 60,
+  "pressure": 1013.25
+}
+```
+
+Or, if data sources publish named sub-series (e.g. `sensors/temperature/inside` and `sensors/temperature/outside`), configure `key_depth = 2` to get a nested measurement where multiple series are merged under a single group:
+
+```json
+{
+  "time": "2024-06-01T12:00:00.000Z",
+  "temperature": { "inside": 23.5, "outside": 30.1 },
+  "humidity": { "room1": 60 }
+}
+```
+
+### How it works
+
+1. **Subscribe** – the flow subscribes to a configurable wildcard topic pattern (e.g. `sensors/#`).
+2. **Buffer** – each incoming message is parsed and stored in an in-memory buffer keyed by the last segment(s) of the originating topic.
+3. **Flush** – on every interval tick (default: 10 s) the buffer is emitted as a single measurement on the configured `output_topic` and then cleared.
+
+### Supported payload formats
+
+| Format                       | Example           |
+| ---------------------------- | ----------------- |
+| Plain number                 | `23.5`            |
+| JSON number                  | `23.5`            |
+| JSON object with `value` key | `{"value": 23.5}` |
+
+Non-numeric payloads (plain strings, booleans, …) are silently ignored.
+
+### Configuration
+
+Copy `params.toml.template` to `params.toml` and adjust as needed:
+
+```toml
+# Output thin-edge.io measurement topic
+output_topic = "te/device/main///m/aggregated"
+
+# 1 = flat values:   "sensors/temperature"        → temperature: 23.5
+# 2 = nested series: "sensors/temperature/inside" → temperature: { inside: 23.5 }
+key_depth = 2
+
+debug = false
+```
+
+### Example: named sub-series (key_depth = 2)
+
+Suppose temperature sensors publish inside and outside readings on separate topics:
+
+```
+sensors/temperature/inside  → 23.5
+sensors/temperature/outside → 30.1
+sensors/humidity/room1      → 60
+```
+
+Set `key_depth = 2`. The second-to-last segment becomes the measurement group
+and the last segment is the named series. Topics sharing the same group are
+**merged** so all arrive as a single nested measurement:
+
+```json
+{
+  "time": "2024-06-01T12:00:00.000Z",
+  "temperature": { "inside": 23.5, "outside": 30.1 },
+  "humidity": { "room1": 60 }
+}
+```
+
+### flow.toml interval
+
+The `interval` setting in `flow.toml` controls how often the buffer is flushed.
+The default is `10s`. Increase it (e.g. `60s`) to widen the collection window,
+giving slower data sources more time to publish before the measurement is sent.

--- a/flows/measurement-aggregator/flow.toml
+++ b/flows/measurement-aggregator/flow.toml
@@ -1,0 +1,22 @@
+[input.mqtt]
+# Subscribe to MQTT topics that carry individual datapoint values.
+# Customize to match your data sources – supports MQTT wildcards:
+#   +  matches exactly one topic level
+#   #  matches any number of trailing topic levels
+#
+# Examples:
+#   "sensors/#"          – all topics under the "sensors" prefix
+#   "factory/+/+"        – two-level topics under "factory"
+#   "plant1/+/+/value"   – value topics under a plant hierarchy
+topics = ["sensors/#"]
+
+[[steps]]
+script = "lib/main.js"
+
+# Flush the buffer and emit one aggregated measurement every 10 seconds.
+# Increase this value if you want a wider collection window.
+interval = "10s"
+
+config.output_topic = "${.params.output_topic}"
+config.key_depth = "${.params.key_depth}"
+config.debug = "${.params.debug}"

--- a/flows/measurement-aggregator/package.json
+++ b/flows/measurement-aggregator/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "measurement-aggregator",
+  "version": "0.1.0",
+  "description": "Collect individual per-topic MQTT datapoints and emit them as a single aggregated thin-edge.io measurement",
+  "source": "src/main.ts",
+  "module": "lib/main.js",
+  "type": "module",
+  "tedge": {
+    "mapper": "local"
+  },
+  "scripts": {
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "test": "jest --coverageProvider=v8 --coverage"
+  },
+  "author": "thin-edge.io",
+  "license": "Apache-2.0"
+}

--- a/flows/measurement-aggregator/params.toml.template
+++ b/flows/measurement-aggregator/params.toml.template
@@ -1,0 +1,21 @@
+# thin-edge.io measurement topic where the aggregated measurement is published.
+# Change the trailing segment to set the measurement type.
+output_topic = "te/device/main///m/aggregated"
+
+# Number of trailing topic segments used to build the measurement key.
+#
+# key_depth = 1 (default): the last topic segment becomes the group name and
+# the value is stored as a flat number in the measurement.
+#   "sensors/humidity"            →  { humidity: 60 }
+#   "sensors/pressure"            →  { pressure: 1013.25 }
+#
+# key_depth = 2: the second-to-last segment is the group name and the last
+# segment is a named series within that group.  Messages that share the same
+# group are merged into a nested object.
+#   "sensors/temperature/inside"  →  { temperature: { inside: 23.5 } }
+#   "sensors/temperature/outside" →  { temperature: { outside: 30.1 } }
+#                                     (merged → { temperature: { inside: 23.5, outside: 30.1 } })
+key_depth = 2
+
+# Enable debug logging
+debug = false

--- a/flows/measurement-aggregator/src/main.ts
+++ b/flows/measurement-aggregator/src/main.ts
@@ -1,0 +1,208 @@
+import { Message, Context, decodePayload } from "../../common/tedge";
+
+export interface Config {
+  // Enable debug logging
+  debug?: boolean;
+  // thin-edge.io measurement topic to publish the aggregated measurement to
+  output_topic?: string;
+  // Number of trailing topic segments used to build the measurement key.
+  // key_depth=1 (default): last segment → group name, value stored flat.
+  //   topic "sensors/humidity"             → { humidity: 60 }
+  // key_depth=2: second-to-last → group, last → named series, value nested.
+  //   topic "sensors/temperature/inside"   → { temperature: { inside: 23.5 } }
+  //   topic "sensors/temperature/outside"  → { temperature: { outside: 30.1 } }  (merged)
+  key_depth?: number;
+}
+
+export interface FlowContext extends Context {
+  config: Config;
+}
+
+// depth=1: flat number per group; depth=2: named series map per group
+type MeasurementBuffer = Record<string, number | Record<string, number>>;
+
+function getBuffer(context: FlowContext): MeasurementBuffer {
+  return context.flow.get("buffer") ?? {};
+}
+
+function setBuffer(context: FlowContext, buf: MeasurementBuffer): void {
+  context.flow.set("buffer", buf);
+}
+
+/**
+ * Extract the measurement group and optional series name from the last `depth`
+ * segments of an MQTT topic.
+ *
+ * depth=1: group = last segment, series = undefined  → flat numeric value
+ * depth=2: group = second-to-last, series = last     → nested series value
+ *
+ * Examples (depth=1):
+ *   "sensors/humidity"            → { group: "humidity" }
+ *   "sensors/room1/temperature"   → { group: "temperature" }
+ *
+ * Examples (depth=2):
+ *   "sensors/temperature/inside"  → { group: "temperature", series: "inside" }
+ *   "sensors/temperature/outside" → { group: "temperature", series: "outside" }
+ */
+export function extractMeasurementKey(
+  topic: string,
+  depth: number,
+): { group: string; series?: string } {
+  const segments = topic.split("/");
+  if (depth >= 2 && segments.length >= 2) {
+    return {
+      group: segments[segments.length - 2],
+      series: segments[segments.length - 1],
+    };
+  }
+  return { group: segments[segments.length - 1] };
+}
+
+/**
+ * Parse a raw MQTT payload into a numeric value.
+ *
+ * Supported payload formats:
+ *   - Plain numeric string: "23.5"
+ *   - JSON number: 23.5
+ *   - JSON object with a "value" key: {"value": 23.5}
+ *
+ * Returns `undefined` if the payload cannot be interpreted as a number.
+ */
+export function parseNumericPayload(raw: string): number | undefined {
+  const trimmed = raw.trim();
+
+  if (trimmed === "") return undefined;
+
+  // Fast path: plain numeric string
+  const direct = Number(trimmed);
+  if (Number.isFinite(direct)) return direct;
+
+  // Try JSON
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed === "number" && Number.isFinite(parsed)) {
+      return parsed;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "value" in parsed &&
+      Number.isFinite(Number(parsed.value))
+    ) {
+      return Number(parsed.value);
+    }
+  } catch {
+    // not valid JSON – fall through
+  }
+
+  return undefined;
+}
+
+/**
+ * Buffer an incoming single-topic datapoint into flow state.
+ *
+ * With key_depth=1 (default) the last topic segment becomes the measurement
+ * group and the value is stored as a plain number (thin-edge flat format).
+ *
+ * With key_depth=2 the second-to-last segment is the group and the last
+ * segment is a named series within that group.  Multiple messages sharing the
+ * same group are merged, building a nested series map for that group.
+ *
+ * The value is not forwarded immediately; it is held until `onInterval` fires.
+ */
+export function onMessage(message: Message, context: FlowContext): Message[] {
+  const { debug = false, key_depth = 1 } = context.config;
+
+  if (debug) {
+    console.log("onMessage config", { key_depth, raw_config: context.config });
+  }
+
+  const raw = decodePayload(message.payload);
+  const value = parseNumericPayload(raw);
+
+  if (value === undefined) {
+    if (debug) {
+      console.log("Skipping non-numeric payload", {
+        topic: message.topic,
+        payload: raw,
+      });
+    }
+    return [];
+  }
+
+  const { group, series } = extractMeasurementKey(message.topic, key_depth);
+  const buf = getBuffer(context);
+
+  if (series !== undefined) {
+    // Nested path: merge the incoming series into the group's series map
+    const existing = (buf[group] as Record<string, number>) ?? {};
+    buf[group] = { ...existing, [series]: value };
+  } else {
+    // Flat path: store the value directly under the group name
+    buf[group] = value;
+  }
+
+  setBuffer(context, buf);
+
+  if (debug) {
+    console.log("Buffered datapoint", {
+      topic: message.topic,
+      group,
+      series,
+      value,
+      bufferSize: Object.keys(buf).length,
+    });
+  }
+
+  return [];
+}
+
+/**
+ * Flush the buffered datapoints as a single thin-edge.io measurement.
+ *
+ * key_depth=1 produces flat measurement fragments:
+ *   { "time": "...", "temperature": 23.5, "humidity": 60 }
+ *
+ * key_depth=2 produces named-series fragments and multiple topics with the
+ * same group are merged into a single nested object:
+ *   { "time": "...", "temperature": { "inside": 23.5, "outside": 30.1 } }
+ *
+ * Both formats are valid thin-edge.io measurement payloads.
+ * The buffer is cleared after each flush so the next window starts fresh.
+ */
+export function onInterval(time: Date, context: FlowContext): Message[] {
+  const { debug = false, output_topic = "te/device/main///m/aggregated" } =
+    context.config;
+
+  const buf = getBuffer(context);
+
+  if (Object.keys(buf).length === 0) {
+    if (debug) {
+      console.log("onInterval: buffer is empty, nothing to emit");
+    }
+    return [];
+  }
+
+  const measurement: Record<string, any> = {
+    time: time.toISOString(),
+    ...buf,
+  };
+
+  // Clear the buffer so the next window starts fresh
+  setBuffer(context, {});
+
+  if (debug) {
+    console.log("Emitting aggregated measurement", {
+      output_topic,
+      groupCount: Object.keys(buf).length,
+    });
+  }
+
+  return [
+    {
+      time,
+      topic: output_topic,
+      payload: JSON.stringify(measurement),
+    },
+  ];
+}

--- a/flows/measurement-aggregator/tests/main.test.ts
+++ b/flows/measurement-aggregator/tests/main.test.ts
@@ -1,0 +1,294 @@
+import { expect, test, describe } from "@jest/globals";
+import * as tedge from "../../common/tedge";
+import * as flow from "../src/main";
+
+const FLUSH_TIME = new Date("2024-06-01T12:00:00.000Z");
+
+// ─── extractMeasurementKey ───────────────────────────────────────────────────
+
+describe("extractMeasurementKey", () => {
+  test("depth=1: returns the last segment as group, no series", () => {
+    expect(flow.extractMeasurementKey("sensors/room1/temperature", 1)).toEqual({
+      group: "temperature",
+    });
+  });
+
+  test("depth=1: single-segment topic", () => {
+    expect(flow.extractMeasurementKey("temperature", 1)).toEqual({
+      group: "temperature",
+    });
+  });
+
+  test("depth=2: second-to-last is group, last is series", () => {
+    expect(flow.extractMeasurementKey("sensors/temperature/inside", 2)).toEqual(
+      { group: "temperature", series: "inside" },
+    );
+  });
+
+  test("depth=2: different series under the same group", () => {
+    expect(
+      flow.extractMeasurementKey("sensors/temperature/outside", 2),
+    ).toEqual({ group: "temperature", series: "outside" });
+  });
+
+  test("depth=2: two-segment topic uses both segments", () => {
+    expect(flow.extractMeasurementKey("temperature/inside", 2)).toEqual({
+      group: "temperature",
+      series: "inside",
+    });
+  });
+});
+
+// ─── parseNumericPayload ──────────────────────────────────────────────────────
+
+describe("parseNumericPayload", () => {
+  test("parses a plain integer string", () => {
+    expect(flow.parseNumericPayload("42")).toBe(42);
+  });
+
+  test("parses a plain float string", () => {
+    expect(flow.parseNumericPayload("23.5")).toBeCloseTo(23.5);
+  });
+
+  test("parses a JSON number", () => {
+    expect(flow.parseNumericPayload("60")).toBe(60);
+  });
+
+  test("parses a JSON object with a value key", () => {
+    expect(flow.parseNumericPayload('{"value": 1013.25}')).toBeCloseTo(1013.25);
+  });
+
+  test("returns undefined for a plain string", () => {
+    expect(flow.parseNumericPayload("hello")).toBeUndefined();
+  });
+
+  test("returns undefined for a JSON string value", () => {
+    expect(flow.parseNumericPayload('"hello"')).toBeUndefined();
+  });
+
+  test("returns undefined for an empty payload", () => {
+    expect(flow.parseNumericPayload("")).toBeUndefined();
+  });
+});
+
+// ─── onMessage ────────────────────────────────────────────────────────────────
+
+describe("onMessage", () => {
+  test("depth=1: stores a flat numeric value under the group name", () => {
+    const context = tedge.createContext({ key_depth: 1 });
+    const output = flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "23.5" },
+      context,
+    );
+    expect(output).toHaveLength(0);
+    expect(context.flow.get("buffer")).toEqual({ temperature: 23.5 });
+  });
+
+  test("depth=1: buffers a JSON {value} payload as a flat number", () => {
+    const context = tedge.createContext({ key_depth: 1 });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/humidity", payload: '{"value": 60}' },
+      context,
+    );
+    expect(context.flow.get("buffer")).toEqual({ humidity: 60 });
+  });
+
+  test("depth=1: accumulates multiple flat datapoints", () => {
+    const context = tedge.createContext({ key_depth: 1 });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "23.5" },
+      context,
+    );
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/humidity", payload: "60" },
+      context,
+    );
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/pressure", payload: "1013.25" },
+      context,
+    );
+    expect(context.flow.get("buffer")).toEqual({
+      temperature: 23.5,
+      humidity: 60,
+      pressure: 1013.25,
+    });
+  });
+
+  test("depth=1: overwrites a flat value when the same topic arrives twice", () => {
+    const context = tedge.createContext({ key_depth: 1 });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "20" },
+      context,
+    );
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "25" },
+      context,
+    );
+    expect(context.flow.get("buffer")).toEqual({ temperature: 25 });
+  });
+
+  test("depth=2: stores a nested series under the group name", () => {
+    const context = tedge.createContext({ key_depth: 2 });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature/inside", payload: "22" },
+      context,
+    );
+    expect(context.flow.get("buffer")).toEqual({
+      temperature: { inside: 22 },
+    });
+  });
+
+  test("depth=2: merges multiple series arriving under the same group", () => {
+    const context = tedge.createContext({ key_depth: 2 });
+    flow.onMessage(
+      {
+        time: new Date(),
+        topic: "sensors/temperature/inside",
+        payload: "23.5",
+      },
+      context,
+    );
+    flow.onMessage(
+      {
+        time: new Date(),
+        topic: "sensors/temperature/outside",
+        payload: "30.1",
+      },
+      context,
+    );
+    expect(context.flow.get("buffer")).toEqual({
+      temperature: { inside: 23.5, outside: 30.1 },
+    });
+  });
+
+  test("depth=2: accumulates different groups independently", () => {
+    const context = tedge.createContext({ key_depth: 2 });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature/inside", payload: "22" },
+      context,
+    );
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/humidity/room1", payload: "60" },
+      context,
+    );
+    expect(context.flow.get("buffer")).toEqual({
+      temperature: { inside: 22 },
+      humidity: { room1: 60 },
+    });
+  });
+
+  test("ignores non-numeric payloads and leaves buffer unchanged", () => {
+    const context = tedge.createContext({});
+    const output = flow.onMessage(
+      { time: new Date(), topic: "sensors/status", payload: "online" },
+      context,
+    );
+    expect(output).toHaveLength(0);
+    expect(context.flow.get("buffer") ?? {}).toEqual({});
+  });
+});
+
+// ─── onInterval ───────────────────────────────────────────────────────────────
+
+describe("onInterval", () => {
+  test("depth=1: emits flat values for all buffered groups", () => {
+    const context = tedge.createContext({
+      key_depth: 1,
+      output_topic: "te/device/main///m/sensors",
+    });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "23.5" },
+      context,
+    );
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/humidity", payload: "60" },
+      context,
+    );
+
+    const output = flow.onInterval(FLUSH_TIME, context);
+
+    expect(output).toHaveLength(1);
+    expect(output[0].topic).toBe("te/device/main///m/sensors");
+
+    const payload = tedge.decodeJsonPayload(output[0].payload);
+    expect(payload.time).toBe("2024-06-01T12:00:00.000Z");
+    expect(payload.temperature).toBe(23.5);
+    expect(payload.humidity).toBe(60);
+  });
+
+  test("depth=2: emits nested series maps for each group", () => {
+    const context = tedge.createContext({
+      key_depth: 2,
+      output_topic: "te/device/main///m/sensors",
+    });
+    flow.onMessage(
+      {
+        time: new Date(),
+        topic: "sensors/temperature/inside",
+        payload: "23.5",
+      },
+      context,
+    );
+    flow.onMessage(
+      {
+        time: new Date(),
+        topic: "sensors/temperature/outside",
+        payload: "30.1",
+      },
+      context,
+    );
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/humidity/room1", payload: "60" },
+      context,
+    );
+
+    const output = flow.onInterval(FLUSH_TIME, context);
+
+    expect(output).toHaveLength(1);
+    const payload = tedge.decodeJsonPayload(output[0].payload);
+    expect(payload.time).toBe("2024-06-01T12:00:00.000Z");
+    expect(payload.temperature).toEqual({ inside: 23.5, outside: 30.1 });
+    expect(payload.humidity).toEqual({ room1: 60 });
+  });
+
+  test("uses the default output topic when none configured", () => {
+    const context = tedge.createContext({});
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "21" },
+      context,
+    );
+    const output = flow.onInterval(FLUSH_TIME, context);
+    expect(output[0].topic).toBe("te/device/main///m/aggregated");
+  });
+
+  test("clears the buffer after emission", () => {
+    const context = tedge.createContext({});
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "21" },
+      context,
+    );
+    flow.onInterval(FLUSH_TIME, context);
+
+    // Second interval – buffer should be empty
+    const second = flow.onInterval(FLUSH_TIME, context);
+    expect(second).toHaveLength(0);
+  });
+
+  test("emits nothing when the buffer is empty", () => {
+    const context = tedge.createContext({});
+    const output = flow.onInterval(FLUSH_TIME, context);
+    expect(output).toHaveLength(0);
+  });
+
+  test("measurement time matches the interval time", () => {
+    const context = tedge.createContext({ key_depth: 1 });
+    flow.onMessage(
+      { time: new Date(), topic: "sensors/temperature", payload: "18" },
+      context,
+    );
+    const output = flow.onInterval(FLUSH_TIME, context);
+    expect(output[0].time).toEqual(FLUSH_TIME);
+    const payload = tedge.decodeJsonPayload(output[0].payload);
+    expect(payload.time).toBe(FLUSH_TIME.toISOString());
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,10 @@
         "npm": ">=9.0.0"
       }
     },
+    "flows/measurement-aggregator": {
+      "version": "0.1.0",
+      "license": "Apache-2.0"
+    },
     "flows/protobuf-xform": {
       "version": "0.2.1",
       "license": "Apache-2.0",
@@ -5534,6 +5538,10 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/measurement-aggregator": {
+      "resolved": "flows/measurement-aggregator",
+      "link": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,6 +40,9 @@
     },
     "flows/tedge-measurement-batch": {
       "component": "tedge-measurement-batch"
+    },
+    "flows/measurement-aggregator": {
+      "component": "measurement-aggregator"
     }
   }
 }


### PR DESCRIPTION
Add an aggregator example which collects messages from a given topic, and groups them together in a single thin-edge.io measurement which then get published to the connected mapper.