### PR TITLE
chore: add update-lockfile job to regenerate package-lock.json after release

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -1,0 +1,38 @@
+name: Update lockfile in release PR
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  update-lockfile:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          # Use a PAT so the resulting commit triggers CI on the PR.
+          # Falls back to GITHUB_TOKEN (commit won't trigger CI but still
+          # keeps the lock file up-to-date before merge).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+
+      - name: Regenerate package-lock.json
+        run: npm install --package-lock-only
+
+      - name: Commit updated package-lock.json
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git diff --staged --quiet || git commit -m "chore: update package-lock.json"
+          git push


### PR DESCRIPTION
Fix a problem where the package-lock.json file gets out of sync after a release. This PR attempts to fix it by updating the release PR after it is created