### PR TITLE
chore(thingsboard-registration): use `onStartup()` for initialization

### DIFF
--- a/flows/thingsboard-registration/src/main.ts
+++ b/flows/thingsboard-registration/src/main.ts
@@ -36,15 +36,23 @@ const NAME_TO_ENTITY_PREFIX = "tb-name-to-entity:";
 // Prefix for <(key: entity ID), (value:pending messages)> store
 const MSG_PREFIX = "tb-msg:";
 
+// Initialize the context, by registering the main device name into the mapper key-value store.
+// This is to ensure the main device is registered even if the registration message is not published.
+export function onStartup(time: Date, context: FlowContext): void {
+  const { main_device_name = "MAIN" } = context.config;
+  const lookupKey = `${ENTITY_TO_NAME_PREFIX}device/main//`;
+  const reverseLookupKey = `${NAME_TO_ENTITY_PREFIX}${main_device_name}`;
+
+  context.mapper.set(lookupKey, main_device_name);
+  context.mapper.set(reverseLookupKey, "device/main//");
+}
+
 export function onMessage(message: Message, context: FlowContext): Message[] {
   const {
     main_device_name = "MAIN",
     default_device_profile = "default",
     max_pending_messages = 100,
   } = context.config;
-
-  // It would be good if we have `onStartup` hook to initialize the main device
-  initializeMainDevice(context, main_device_name);
 
   const { entityId, topicSegments } = parseTopicSegments(message.topic);
   const lookupKey = `${ENTITY_TO_NAME_PREFIX}${entityId}`;
@@ -96,21 +104,6 @@ export function onMessage(message: Message, context: FlowContext): Message[] {
   storePendingMessage(context, max_pending_messages, pendingMsgKey, message);
 
   return [];
-}
-
-// The registration message for the main device is not always published,
-// hence add it to the KV store here
-function initializeMainDevice(
-  context: FlowContext,
-  mainDeviceName: string,
-): void {
-  const lookupKey = `${ENTITY_TO_NAME_PREFIX}device/main//`;
-  const reverseLookupKey = `${NAME_TO_ENTITY_PREFIX}${mainDeviceName}`;
-
-  if (!context.mapper.get(lookupKey)) {
-    context.mapper.set(lookupKey, mainDeviceName);
-    context.mapper.set(reverseLookupKey, "device/main//");
-  }
 }
 
 function parseTopicSegments(topic: string): {

--- a/flows/thingsboard-registration/tests/main.test.ts
+++ b/flows/thingsboard-registration/tests/main.test.ts
@@ -21,6 +21,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const result = flow.onMessage(message, context);
 
@@ -67,6 +68,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const result = flow.onMessage(message, context);
 
@@ -90,6 +92,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const result = flow.onMessage(message, context);
 
@@ -113,6 +116,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const result = flow.onMessage(message, context);
       expect(result).toHaveLength(1);
@@ -144,6 +148,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const result = flow.onMessage(message, context);
 
@@ -179,6 +184,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const result = flow.onMessage(message, context);
 
@@ -200,6 +206,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 3,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       for (let i = 0; i < 5; i++) {
         const message: tedge.Message = {
@@ -231,6 +238,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       // First, send some non-registration messages
       for (let i = 0; i < 3; i++) {
@@ -273,6 +281,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       // Send measurement message
       const measurementMessage: tedge.Message = {
@@ -322,6 +331,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       // First register the device
       const registrationMessage: tedge.Message = {
@@ -354,6 +364,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       // Register the device
       const registrationMessage: tedge.Message = {
@@ -387,6 +398,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -406,34 +418,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
-
-      // Register device first
-      const registrationMessage: tedge.Message = {
-        time: tedge.mockGetTime(),
-        topic: "te/device/child0//",
-        payload: JSON.stringify({
-          "@type": "child-device",
-        }),
-      };
-      flow.onMessage(registrationMessage, context);
-
-      // Send measurement
-      const message: tedge.Message = {
-        time: tedge.mockGetTime(),
-        topic: "te/device/child0///m/humidity",
-        payload: JSON.stringify({ humidity: 60 }),
-      };
-
-      const result = flow.onMessage(message, context);
-      expect(result[0].topic).toBe("tbflow/device/child0///m/humidity");
-    });
-
-    test("should replace te/ with tbflow/ in forwarded messages", () => {
-      const context = tedge.createContext({
-        main_device_name: "MAIN",
-        default_device_profile: "default",
-        max_pending_messages: 100,
-      });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       // Register device first
       const registrationMessage: tedge.Message = {
@@ -458,7 +443,7 @@ describe("ThingsBoard Registration Flow", () => {
   });
 
   describe("Edge Cases", () => {
-    test("main device should be added to the KV store", () => {
+    test("main device should be added to the KV store on startup", () => {
       const context = tedge.createContext({
         main_device_name: "MAIN DEVICE",
         default_device_profile: "default",
@@ -472,13 +457,7 @@ describe("ThingsBoard Registration Flow", () => {
         undefined,
       );
 
-      const message: tedge.Message = {
-        time: tedge.mockGetTime(),
-        topic: "te/device/child0//",
-        payload: JSON.stringify({}),
-      };
-
-      flow.onMessage(message, context);
+      flow.onStartup(tedge.mockGetTime(), context);
       expect(context.mapper.get("tb-entity-to-name:device/main//")).toBe(
         "MAIN DEVICE",
       );
@@ -493,6 +472,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -512,6 +492,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -533,6 +514,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -559,6 +541,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -581,6 +564,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -605,6 +589,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -628,6 +613,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -651,6 +637,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),
@@ -672,6 +659,7 @@ describe("ThingsBoard Registration Flow", () => {
         default_device_profile: "default",
         max_pending_messages: 100,
       });
+      flow.onStartup(tedge.mockGetTime(), context);
 
       const message: tedge.Message = {
         time: tedge.mockGetTime(),


### PR DESCRIPTION
Since `onStartup()` function is now available, move initializing function from `onMessage()` to `onStartup()`.