### PR TITLE
refactor: remove the test and dev label usage and build options

### DIFF
--- a/flows/certificate-alert/package.json
+++ b/flows/certificate-alert/package.json
@@ -6,7 +6,7 @@
   "module": "lib/main.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "tedge": {

--- a/flows/cloud-mapper-commands/package.json
+++ b/flows/cloud-mapper-commands/package.json
@@ -6,7 +6,7 @@
   "module": "lib/main.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/cloud-mapper-telemetry/package.json
+++ b/flows/cloud-mapper-telemetry/package.json
@@ -6,7 +6,7 @@
   "module": "lib/main.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/jsonata-xform/package.json
+++ b/flows/jsonata-xform/package.json
@@ -6,7 +6,7 @@
   "module": "lib/main.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "tedge": {

--- a/flows/log-surge/package.json
+++ b/flows/log-surge/package.json
@@ -6,7 +6,7 @@
   "module": "lib/main.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "tedge": {

--- a/flows/log-surge/src/main.ts
+++ b/flows/log-surge/src/main.ts
@@ -105,7 +105,7 @@ export function onMessage(message: Message, context: FlowContext): Message[] {
     };
   };
   if (!text_filter.map((v) => RegExp(v)).every(contains(output.text))) {
-    TEST: if (debug) {
+    if (debug) {
       console.log("Skipping message as it did not match the text filter", {
         text_filter,
       });
@@ -139,9 +139,6 @@ export function onInterval(time: Date, context: FlowContext) {
     stats_topic = "stats/logs",
     threshold = {},
   } = context.config || {};
-  TEST: if (debug) {
-    console.log("Calling tick");
-  }
 
   const { info = 0, warning = 0, error = 0, total = 0 } = threshold;
   const state = getState(context);
@@ -191,9 +188,6 @@ export function onInterval(time: Date, context: FlowContext) {
       }),
     });
   } else if (state.ran) {
-    TEST: if (debug) {
-      console.log("clearing log_surge alarm (if present)");
-    }
     output.push({
       time,
       topic: `te/device/main///a/log_surge`,

--- a/flows/measurement-aggregator/package.json
+++ b/flows/measurement-aggregator/package.json
@@ -9,7 +9,7 @@
     "mapper": "local"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/protobuf-xform/package.json
+++ b/flows/protobuf-xform/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "prebuild": "npx buf generate",
-    "build": "esbuild src/main*.ts --target=es2018 --bundle --outdir=lib/ --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main*.ts --target=es2018 --bundle --outdir=lib/ --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "tedge": {

--- a/flows/tedge-config-context/package.json
+++ b/flows/tedge-config-context/package.json
@@ -9,7 +9,7 @@
     "mapper": "local"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/tedge-events/package.json
+++ b/flows/tedge-events/package.json
@@ -9,7 +9,7 @@
     "mapper": "local"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/tedge-measurement-batch/package.json
+++ b/flows/tedge-measurement-batch/package.json
@@ -9,7 +9,7 @@
     "mapper": "c8y"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/thingsboard-registration/package.json
+++ b/flows/thingsboard-registration/package.json
@@ -9,7 +9,7 @@
     "mapper": "thingsboard"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/thingsboard-server-rpc/package.json
+++ b/flows/thingsboard-server-rpc/package.json
@@ -9,7 +9,7 @@
     "mapper": "thingsboard"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/thingsboard-telemetry/package.json
+++ b/flows/thingsboard-telemetry/package.json
@@ -9,7 +9,7 @@
     "mapper": "thingsboard"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/flows/uptime/package.json
+++ b/flows/uptime/package.json
@@ -6,7 +6,7 @@
   "module": "lib/main.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "tedge": {

--- a/flows/x509-cert-issuer/package.json
+++ b/flows/x509-cert-issuer/package.json
@@ -9,7 +9,7 @@
     "mapper": "local"
   },
   "scripts": {
-    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     "test": "jest --coverageProvider=v8 --coverage"
   },
   "author": "thin-edge.io",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,8 +3,6 @@ import type { Config } from "jest";
 
 const esbuildOptions = {
   target: "es2018",
-  // ignore labels for test coverage
-  dropLabels: ["TEST", "DEV"],
 };
 
 const config: Config = {

--- a/scripts/create-flow.js
+++ b/scripts/create-flow.js
@@ -23,7 +23,7 @@ const packageTemplate = {
   },
   scripts: {
     build:
-      "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm --drop-labels=DEV,TEST",
+      "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
     test: "jest --coverageProvider=v8 --coverage",
   },
   author: "thin-edge.io",


### PR DESCRIPTION
The labels was an interesting idea however in the end they didn't provide much value overall so removing them would simplify the setup