### PR TITLE
feat: tedge-compat flow to handle mapping of deprecated tedge 0.x topics to te/ topics

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -13,5 +13,6 @@
   "flows/tedge-config-context": "1.0.1",
   "flows/tedge-events": "1.0.0",
   "flows/tedge-measurement-batch": "1.0.0",
-  "flows/x509-cert-issuer": "1.0.0"
+  "flows/x509-cert-issuer": "1.0.0",
+  "flows/tedge-compat": "0.0.1"
 }

--- a/flows/tedge-compat/README.md
+++ b/flows/tedge-compat/README.md
@@ -1,0 +1,43 @@
+## tedge-compat
+
+Translates legacy `tedge/` MQTT topics to the new `te/` topic structure introduced in thin-edge.io 1.0.
+
+The legacy topic scheme is still supported via a built-in compatibility layer in `tedge-agent`, but that layer is deprecated. Use this flow to migrate any legacy publisher to the new API without modifying the publisher itself.
+
+See the official [MQTT topics backward-compatibility docs](https://thin-edge.github.io/thin-edge.io/next/legacy/mqtt-topics/#backward-compatibility) for full details.
+
+### Topic mappings
+
+#### Main device
+
+| Type         | Legacy topic                     | New topic                   | Payload change                      |
+| ------------ | -------------------------------- | --------------------------- | ----------------------------------- |
+| Measurements | `tedge/measurements`             | `te/device/main///m/`       | None                                |
+| Events       | `tedge/events/<type>`            | `te/device/main///e/<type>` | None                                |
+| Alarms       | `tedge/alarms/<severity>/<type>` | `te/device/main///a/<type>` | `"severity"` field added to payload |
+
+#### Child devices
+
+| Type         | Legacy topic                                | New topic                         | Payload change                      |
+| ------------ | ------------------------------------------- | --------------------------------- | ----------------------------------- |
+| Measurements | `tedge/measurements/<child_id>`             | `te/device/<child_id>///m/`       | None                                |
+| Events       | `tedge/events/<type>/<child_id>`            | `te/device/<child_id>///e/<type>` | None                                |
+| Alarms       | `tedge/alarms/<severity>/<type>/<child_id>` | `te/device/<child_id>///a/<type>` | `"severity"` field added to payload |
+
+### Input topics
+
+The flow subscribes to all legacy telemetry topics:
+
+```
+tedge/measurements
+tedge/measurements/+
+tedge/events/+
+tedge/events/+/+
+tedge/alarms/+/+
+tedge/alarms/+/+/+
+```
+
+### Notes
+
+- Alarm severity is moved from the topic into the payload as `{ "severity": "<severity>", ... }`.
+- Messages on unrecognised topics are silently dropped.

--- a/flows/tedge-compat/flow.toml
+++ b/flows/tedge-compat/flow.toml
@@ -1,0 +1,17 @@
+[input]
+mqtt.topics = [
+    "tedge/measurements",
+    "tedge/events/+",
+    "tedge/alarms/+/+",
+
+    # child devices
+    "tedge/measurements/+",
+    "tedge/events/+/+",
+    "tedge/alarms/+/+/+",
+]
+
+[config]
+topic_root = "${params.topic_root}"
+
+[[steps]]
+script = "lib/main.js"

--- a/flows/tedge-compat/package.json
+++ b/flows/tedge-compat/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "tedge-compat",
+  "version": "0.0.1",
+  "description": "Flow description",
+  "source": "src/main.ts",
+  "module": "lib/main.js",
+  "type": "module",
+  "tedge": {
+    "mapper": "c8y"
+  },
+  "scripts": {
+    "build": "esbuild src/main.ts --target=es2018 --bundle --outfile=lib/main.js --format=esm",
+    "test": "jest --coverageProvider=v8 --coverage"
+  },
+  "author": "thin-edge.io",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "esbuild": "^0.25.5",
+    "esbuild-register": "^3.6.0",
+    "jest": "^30.0.4",
+    "jest-esbuild": "^0.4.0",
+    "prettier": "3.6.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/flows/tedge-compat/params.toml.template
+++ b/flows/tedge-compat/params.toml.template
@@ -1,0 +1,1 @@
+topic_root = "te"

--- a/flows/tedge-compat/src/main.ts
+++ b/flows/tedge-compat/src/main.ts
@@ -1,0 +1,88 @@
+import {
+  Message,
+  Context,
+  decodePayload,
+  decodeJsonPayload,
+} from "../../common/tedge";
+
+function isEmptyPayload(payload: Message["payload"]): boolean {
+  return decodePayload(payload).trim() === "";
+}
+
+export interface Config {
+  topic_root?: string;
+}
+
+export interface FlowContext extends Context {
+  config: Config;
+}
+
+export function onMessage(message: Message, context: FlowContext): Message[] {
+  const { topic_root = "te" } = context.config || {};
+  const parts = message.topic.split("/");
+  const msgType = parts[1]; // measurements | events | alarms
+
+  if (msgType === "measurements") {
+    // tedge/measurements                → te/device/main///m/
+    // tedge/measurements/<child_id>     → te/device/<child_id>///m/
+    const device = parts[2] ?? "main";
+    return [
+      {
+        time: message.time,
+        topic: `${topic_root}/device/${device}///m/`,
+        payload: message.payload,
+      },
+    ];
+  }
+
+  if (msgType === "events") {
+    if (parts.length === 3) {
+      // tedge/events/<type>             → te/device/main///e/<type>
+      return [
+        {
+          time: message.time,
+          topic: `${topic_root}/device/main///e/${parts[2]}`,
+          payload: message.payload,
+        },
+      ];
+    }
+    // tedge/events/<type>/<child_id>    → te/device/<child_id>///e/<type>
+    return [
+      {
+        time: message.time,
+        topic: `${topic_root}/device/${parts[3]}///e/${parts[2]}`,
+        payload: message.payload,
+      },
+    ];
+  }
+
+  if (msgType === "alarms") {
+    const severity = parts[2];
+    const type = parts[3];
+    const device = parts.length === 4 ? "main" : parts[4];
+    const newTopic = `${topic_root}/device/${device}///a/${type}`;
+
+    // An empty retained message clears the alarm — pass it through as-is.
+    if (isEmptyPayload(message.payload)) {
+      return [
+        {
+          time: message.time,
+          topic: newTopic,
+          payload: message.payload,
+          mqtt: { retain: true, qos: 1 },
+        },
+      ];
+    }
+
+    const payload = decodeJsonPayload(message.payload);
+    return [
+      {
+        time: message.time,
+        topic: newTopic,
+        payload: JSON.stringify({ ...payload, severity }),
+        mqtt: { retain: true, qos: 1 },
+      },
+    ];
+  }
+  return [];
+}

--- a/flows/tedge-compat/tests/main.test.ts
+++ b/flows/tedge-compat/tests/main.test.ts
@@ -1,0 +1,166 @@
+import { expect, test, describe } from "@jest/globals";
+import * as tedge from "../../common/tedge";
+import * as flow from "../src/main";
+
+const ctx = tedge.createContext({});
+const t = new Date("2026-01-01T00:00:00.000Z");
+
+function msg(topic: string, payload: object): tedge.Message {
+  return { time: t, topic, payload: JSON.stringify(payload) };
+}
+
+// --- measurements ---
+
+describe("measurements", () => {
+  test("main device", () => {
+    const out = flow.onMessage(
+      msg("tedge/measurements", { temperature: 22 }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/main///m/");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({
+      temperature: 22,
+    });
+  });
+
+  test("child device", () => {
+    const out = flow.onMessage(
+      msg("tedge/measurements/child01", { humidity: 55 }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/child01///m/");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({ humidity: 55 });
+  });
+});
+
+// --- events ---
+
+describe("events", () => {
+  test("main device", () => {
+    const out = flow.onMessage(
+      msg("tedge/events/login", { text: "user logged in" }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/main///e/login");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({
+      text: "user logged in",
+    });
+  });
+
+  test("child device", () => {
+    const out = flow.onMessage(
+      msg("tedge/events/login/child01", { text: "user logged in" }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/child01///e/login");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({
+      text: "user logged in",
+    });
+  });
+});
+
+// --- alarms ---
+
+describe("alarms", () => {
+  test("main device — severity added to payload", () => {
+    const out = flow.onMessage(
+      msg("tedge/alarms/critical/HighTemp", { text: "too hot" }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/main///a/HighTemp");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({
+      severity: "critical",
+      text: "too hot",
+    });
+  });
+
+  test("main device — severity in topic has precedence over severity in body", () => {
+    const out = flow.onMessage(
+      msg("tedge/alarms/critical/HighTemp", {
+        text: "too hot",
+        severity: "warning",
+      }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/main///a/HighTemp");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({
+      severity: "critical",
+      text: "too hot",
+    });
+  });
+
+  test("child device — severity added to payload", () => {
+    const out = flow.onMessage(
+      msg("tedge/alarms/major/DiskFull/child01", { text: "disk full" }),
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/child01///a/DiskFull");
+    expect(tedge.decodeJsonPayload(out[0].payload)).toEqual({
+      severity: "major",
+      text: "disk full",
+    });
+  });
+
+  test("main device — empty payload clears the alarm", () => {
+    const out = flow.onMessage(
+      { time: t, topic: "tedge/alarms/critical/HighTemp", payload: "" },
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/main///a/HighTemp");
+    expect(tedge.decodePayload(out[0].payload)).toBe("");
+  });
+
+  test("child device — empty payload clears the alarm", () => {
+    const out = flow.onMessage(
+      { time: t, topic: "tedge/alarms/major/DiskFull/child01", payload: "" },
+      ctx,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].topic).toBe("te/device/child01///a/DiskFull");
+    expect(tedge.decodePayload(out[0].payload)).toBe("");
+  });
+});
+
+// --- unknown topic ---
+
+describe("unknown topic", () => {
+  test("returns empty array", () => {
+    const out = flow.onMessage(msg("tedge/unknown/foo", {}), ctx);
+    expect(out).toHaveLength(0);
+  });
+});
+
+// --- custom topic_root ---
+
+describe("custom topic_root", () => {
+  const customCtx = tedge.createContext({ topic_root: "custom" });
+
+  test("measurements use custom root", () => {
+    const out = flow.onMessage(
+      msg("tedge/measurements", { temp: 1 }),
+      customCtx,
+    );
+    expect(out[0].topic).toBe("custom/device/main///m/");
+  });
+
+  test("events use custom root", () => {
+    const out = flow.onMessage(msg("tedge/events/login", {}), customCtx);
+    expect(out[0].topic).toBe("custom/device/main///e/login");
+  });
+
+  test("alarms use custom root", () => {
+    const out = flow.onMessage(
+      msg("tedge/alarms/critical/HighTemp", {}),
+      customCtx,
+    );
+    expect(out[0].topic).toBe("custom/device/main///a/HighTemp");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,503 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "flows/tedge-compat": {
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "esbuild": "^0.25.5",
+        "esbuild-register": "^3.6.0",
+        "jest": "^30.0.4",
+        "jest-esbuild": "^0.4.0",
+        "prettier": "3.6.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "flows/tedge-compat/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "flows/tedge-config-context": {
       "version": "1.0.1",
       "license": "Apache-2.0",
@@ -6523,6 +7020,10 @@
     },
     "node_modules/tedge": {
       "resolved": "flows/tedge",
+      "link": true
+    },
+    "node_modules/tedge-compat": {
+      "resolved": "flows/tedge-compat",
       "link": true
     },
     "node_modules/tedge-config-context": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,6 +46,9 @@
     },
     "flows/x509-cert-issuer": {
       "component": "x509-cert-issuer"
+    },
+    "flows/tedge-compat": {
+      "component": "tedge-compat"
     }
   }
 }


### PR DESCRIPTION
Translates legacy `tedge/` MQTT topics to the new `te/` topic structure introduced in thin-edge.io 1.0.

The legacy topic scheme is still supported via a built-in compatibility layer in `tedge-agent`, but that layer is deprecated. Use this flow to migrate any legacy publisher to the new API without modifying the publisher itself.

The `tedge/` topics are being deprecated in this PR, https://github.com/thin-edge/thin-edge.io/pull/4105