### PR TITLE
docs: update Cumulocity digital twin manager asset definitions

### DIFF
--- a/flows/certificate-alert/README.md
+++ b/flows/certificate-alert/README.md
@@ -30,6 +30,8 @@ c8y api --raw POST /service/dtm/definitions/properties --template '{
     "jsonSchema": {
         "title": "Flow Parameters - Certificate Alert",
         "description": "Certificate expiration alerts",
+        "additionalProperties": true,
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "properties": {
             "disable_alarms": {
                 "type": "boolean",
@@ -52,7 +54,7 @@ c8y api --raw POST /service/dtm/definitions/properties --template '{
             "disable_twin": {
                 "type": "boolean",
                 "default": false,
-                "title": "Don't publish certificate info via the digital twin",
+                "title": "Do not publish certificate info via the digital twin",
                 "order": 4
             }
         },

--- a/flows/log-surge/README.md
+++ b/flows/log-surge/README.md
@@ -81,11 +81,13 @@ c8y api --raw POST /service/dtm/definitions/properties --template '{
   "jsonSchema": {
     "title": "Flow Parameters - Log Surge Detection",
     "description": "Monitor high amount of log entries",
+    "additionalProperties": true,
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
       "with_logs": {
         "type": "boolean",
         "default": false,
-        "description": "Publish individual log entries (useful for debugging)."
+        "description": "Publish individual log entries"
       },
       "debug": {
         "type": "boolean",
@@ -101,7 +103,7 @@ c8y api --raw POST /service/dtm/definitions/properties --template '{
         "type": "integer",
         "minimum": 0,
         "default": 500,
-        "description": "Total number of log entries (regardless of log level) before triggering an alarm. 0 disables the alarm."
+        "description": "Total number of log entries before triggering an alarm. 0 disables the alarm."
       },
       "threshold_error": {
         "type": "integer",
@@ -121,6 +123,11 @@ c8y api --raw POST /service/dtm/definitions/properties --template '{
         "default": 0,
         "description": "Number of info log entries before triggering an alarm. 0 disables the alarm."
       },
+      "stats_topic": {
+        "type": "string",
+        "default": "stats/logs",
+        "description": "Topic to publish the statistics to"
+      },
       "text_filter": {
         "type": "array",
         "description": "Optional list of regex patterns used to filter log messages. Only matching messages will be included.",
@@ -128,7 +135,7 @@ c8y api --raw POST /service/dtm/definitions/properties --template '{
           "type": "string",
           "format": "regex"
         },
-        "minItems": 1
+        "minItems": 0
       }
     },
     "type": "object"

--- a/flows/uptime/README.md
+++ b/flows/uptime/README.md
@@ -35,18 +35,20 @@ The flow expects the thin-edge.io service status message to be one of the follow
        "jsonSchema": {
            "title": "Flow Parameters - Cumulocity Uptime",
            "description": "Track the uptime",
+           "additionalProperties": true,
+           "$schema": "http://json-schema.org/draft-07/schema#",
            "properties": {
-           "window_size_minutes": {
-               "type": "integer",
-               "default": 1000,
-               "title": "Window Size (Minutes)",
-               "order": 1
-           },
-           "stats_topic": {
-               "type": "string",
-               "title": "Statistics Topic",
-               "order": 2
-           }
+                "window_size_minutes": {
+                    "type": "integer",
+                    "default": 1000,
+                    "title": "Window Size in Minutes",
+                    "order": 1
+                },
+                "stats_topic": {
+                    "type": "string",
+                    "title": "Statistics Topic",
+                    "order": 2
+                }
            },
            "type": "object"
        },


### PR DESCRIPTION
Avoid using unsupported characters in the definitions as it caused rendering issues with the Cumulocity Digital Twin Manager (DTM), though feedback is being provided to the team to accept additional characters.